### PR TITLE
add mysql query normalization

### DIFF
--- a/parsers/mysql/mysql.go
+++ b/parsers/mysql/mysql.go
@@ -102,7 +102,7 @@ type SlowQuery struct {
 	Role            *string  `json:"role,omitempty"`
 	ClientIP        string   `json:"client_ip,omitempty"`
 	Statement       string   `json:"statement,omitempty"`
-	Tables          []string `json:"tables,omitempty"`
+	Tables          string   `json:"tables,omitempty"`
 	skipQuery       bool
 }
 
@@ -310,7 +310,7 @@ func (p *Parser) handleEvent(rawE []string) (SlowQuery, time.Time) {
 	var timeFromComment time.Time
 	var timeFromSet int64
 	query := ""
-	for _, line := range rawE.lines {
+	for _, line := range rawE {
 		// parse each line and populate the SlowQuery object
 		switch {
 		case reTime.MatchString(line):

--- a/parsers/mysql/mysql.go
+++ b/parsers/mysql/mysql.go
@@ -416,7 +416,7 @@ func (e *emptyQueryError) Error() string {
 
 func (p *Parser) processSlowQuery(sq SlowQuery, timestamp time.Time) (event.Event, error) {
 	// if we didn't match any lines at all, skip the query
-	if sq.Query == "" && sq.NormalizedQuery == "" {
+	if sq == (SlowQuery{}) {
 		sq.skipQuery = true
 	}
 

--- a/parsers/mysql/mysql.go
+++ b/parsers/mysql/mysql.go
@@ -307,9 +307,6 @@ func (p *Parser) handleEvents(rawEvents <-chan []string, send chan<- event.Event
 // available.
 func (p *Parser) handleEvent(rawE []string) (SlowQuery, time.Time) {
 	sq := SlowQuery{}
-	logrus.WithFields(logrus.Fields{
-		"rawE": rawE,
-	}).Debug("About to parse event")
 	var timeFromComment time.Time
 	var timeFromSet int64
 	query := ""

--- a/parsers/mysql/mysql_test.go
+++ b/parsers/mysql/mysql_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/honeycombio/mysqltools/query/normalizer"
 )
 
 type slowQueryData struct {
@@ -76,6 +78,8 @@ var sqds = []slowQueryData{
 		},
 		sq: SlowQuery{
 			skipQuery: true,
+			Tables:    []string{},
+			Statement: "",
 		},
 		timestamp:    tUnparseable,
 		psqWillError: true,
@@ -87,20 +91,48 @@ var sqds = []slowQueryData{
 			"show status like 'Uptime';",
 		},
 		sq: SlowQuery{
-			Query: "show status like 'Uptime';",
-			//NormalizedQuery: "show status like ?;",
+			Timestamp:       t2,
+			UnixTime:        1459470669,
+			Query:           "show status like 'Uptime';",
+			NormalizedQuery: "show status like ?;",
+			Tables:          []string{},
+			Statement:       "",
 		},
 		timestamp: t1.Truncate(time.Second),
 	},
 	{
-		rawE: []string{
-			"# Time: not-a-parsable-time-stampZ",
-			"SET timestamp=1459470669;",
-			"SELECT * FROM (SELECT  T1.orderNumber,  STATUS,  SUM(quantityOrdered * priceEach) AS  total FROM orders WHERE total > 1000 AS T1 INNER JOIN orderdetails AS T2 ON T1.orderNumber = T2.orderNumber GROUP BY  orderNumber) T WHERE total > 100;",
+		// fails to parse and we fall back to the scan normalizer
+		rawE: rawEvent{
+			lines: []string{
+				"# Time: not-a-parsable-time-stampZ",
+				"SET timestamp=1459470669;",
+				"SELECT * FROM (SELECT  T1.orderNumber,  STATUS,  SUM(quantityOrdered * priceEach) AS  total FROM orders WHERE total > 1000 AS T1 INNER JOIN orderdetails AS T2 ON T1.orderNumber = T2.orderNumber GROUP BY  orderNumber) T WHERE total > 100;",
+			},
 		},
 		sq: SlowQuery{
-			Query: "SELECT * FROM (SELECT  T1.orderNumber,  STATUS,  SUM(quantityOrdered * priceEach) AS  total FROM orders WHERE total > 1000 AS T1 INNER JOIN orderdetails AS T2 ON T1.orderNumber = T2.orderNumber GROUP BY  orderNumber) T WHERE total > 100;",
-			//NormalizedQuery: "select * from (select t1.ordernumber, status, sum(quantityordered * priceeach) as total from orders where total > ? as t1 inner join orderdetails as t2 on t1.ordernumber = t2.ordernumber group by ordernumber) t where total > ?;",
+			Timestamp:       t2,
+			UnixTime:        1459470669,
+			Query:           "SELECT * FROM (SELECT  T1.orderNumber,  STATUS,  SUM(quantityOrdered * priceEach) AS  total FROM orders WHERE total > 1000 AS T1 INNER JOIN orderdetails AS T2 ON T1.orderNumber = T2.orderNumber GROUP BY  orderNumber) T WHERE total > 100;",
+			NormalizedQuery: "select * from (select t1.ordernumber, status, sum(quantityordered * priceeach) as total from orders where total > ? as t1 inner join orderdetails as t2 on t1.ordernumber = t2.ordernumber group by ordernumber) t where total > ?;",
+			Tables:          []string{},
+			Statement:       "",
+		},
+	},
+	{
+		rawE: rawEvent{
+			lines: []string{
+				"# Time: not-a-parsable-time-stampZ",
+				"SET timestamp=1459470669;",
+				"SELECT * FROM orders WHERE total > 1000",
+			},
+		},
+		sq: SlowQuery{
+			Timestamp:       t2,
+			UnixTime:        1459470669,
+			Query:           "SELECT * FROM orders WHERE total > 1000",
+			NormalizedQuery: "select * from orders where total > ?",
+			Tables:          []string{"orders"},
+			Statement:       "select",
 		},
 		timestamp: t1.Truncate(time.Second),
 	},
@@ -124,7 +156,8 @@ var sqds = []slowQueryData{
 
 func TestHandleEvent(t *testing.T) {
 	p := &Parser{
-		nower: &FakeNower{},
+		nower:      &FakeNower{},
+		normalizer: &normalizer.Parser{},
 	}
 	for i, sqd := range sqds {
 		res, timestamp := p.handleEvent(sqd.rawE)
@@ -140,7 +173,8 @@ func TestHandleEvent(t *testing.T) {
 
 func TestProcessSlowQuery(t *testing.T) {
 	p := &Parser{
-		nower: &FakeNower{},
+		nower:      &FakeNower{},
+		normalizer: &normalizer.Parser{},
 	}
 	for i, sqd := range sqds {
 		res, err := p.processSlowQuery(sqd.sq, sqd.timestamp)

--- a/parsers/mysql/mysql_test.go
+++ b/parsers/mysql/mysql_test.go
@@ -78,8 +78,6 @@ var sqds = []slowQueryData{
 		},
 		sq: SlowQuery{
 			skipQuery: true,
-			Tables:    []string{},
-			Statement: "",
 		},
 		timestamp:    tUnparseable,
 		psqWillError: true,
@@ -93,10 +91,8 @@ var sqds = []slowQueryData{
 		sq: SlowQuery{
 			Timestamp:       t2,
 			UnixTime:        1459470669,
-			Query:           "show status like 'Uptime';",
-			NormalizedQuery: "show status like ?;",
-			Tables:          []string{},
-			Statement:       "",
+			Query:           "show status like 'Uptime'",
+			NormalizedQuery: "show status like ?",
 		},
 		timestamp: t1.Truncate(time.Second),
 	},
@@ -112,10 +108,8 @@ var sqds = []slowQueryData{
 		sq: SlowQuery{
 			Timestamp:       t2,
 			UnixTime:        1459470669,
-			Query:           "SELECT * FROM (SELECT  T1.orderNumber,  STATUS,  SUM(quantityOrdered * priceEach) AS  total FROM orders WHERE total > 1000 AS T1 INNER JOIN orderdetails AS T2 ON T1.orderNumber = T2.orderNumber GROUP BY  orderNumber) T WHERE total > 100;",
-			NormalizedQuery: "select * from (select t1.ordernumber, status, sum(quantityordered * priceeach) as total from orders where total > ? as t1 inner join orderdetails as t2 on t1.ordernumber = t2.ordernumber group by ordernumber) t where total > ?;",
-			Tables:          []string{},
-			Statement:       "",
+			Query:           "SELECT * FROM (SELECT  T1.orderNumber,  STATUS,  SUM(quantityOrdered * priceEach) AS  total FROM orders WHERE total > 1000 AS T1 INNER JOIN orderdetails AS T2 ON T1.orderNumber = T2.orderNumber GROUP BY  orderNumber) T WHERE total > 100",
+			NormalizedQuery: "select * from (select t1.ordernumber, status, sum(quantityordered * priceeach) as total from orders where total > ? as t1 inner join orderdetails as t2 on t1.ordernumber = t2.ordernumber group by ordernumber) t where total > ?",
 		},
 	},
 	{
@@ -123,7 +117,7 @@ var sqds = []slowQueryData{
 			lines: []string{
 				"# Time: not-a-parsable-time-stampZ",
 				"SET timestamp=1459470669;",
-				"SELECT * FROM orders WHERE total > 1000",
+				"SELECT * FROM orders WHERE total > 1000;",
 			},
 		},
 		sq: SlowQuery{
@@ -131,7 +125,7 @@ var sqds = []slowQueryData{
 			UnixTime:        1459470669,
 			Query:           "SELECT * FROM orders WHERE total > 1000",
 			NormalizedQuery: "select * from orders where total > ?",
-			Tables:          []string{"orders"},
+			Tables:          "orders",
 			Statement:       "select",
 		},
 		timestamp: t1.Truncate(time.Second),
@@ -143,8 +137,9 @@ var sqds = []slowQueryData{
 			"use someDB;",
 		},
 		sq: SlowQuery{
-			DB:    "someDB",
-			Query: "use someDB;",
+			DB:              "someDB",
+			Query:           "use someDB",
+			NormalizedQuery: "use someDB",
 		},
 		timestamp: t1.Truncate(time.Second),
 	},

--- a/parsers/mysql/mysql_test.go
+++ b/parsers/mysql/mysql_test.go
@@ -89,40 +89,31 @@ var sqds = []slowQueryData{
 			"show status like 'Uptime';",
 		},
 		sq: SlowQuery{
-			Timestamp:       t2,
-			UnixTime:        1459470669,
 			Query:           "show status like 'Uptime'",
 			NormalizedQuery: "show status like ?",
 		},
 		timestamp: t1.Truncate(time.Second),
 	},
 	{
-		// fails to parse and we fall back to the scan normalizer
-		rawE: rawEvent{
-			lines: []string{
-				"# Time: not-a-parsable-time-stampZ",
-				"SET timestamp=1459470669;",
-				"SELECT * FROM (SELECT  T1.orderNumber,  STATUS,  SUM(quantityOrdered * priceEach) AS  total FROM orders WHERE total > 1000 AS T1 INNER JOIN orderdetails AS T2 ON T1.orderNumber = T2.orderNumber GROUP BY  orderNumber) T WHERE total > 100;",
-			},
+		// fails to parse "Time" but we capture unix time and we fall back to the scan normalizer
+		rawE: []string{
+			"# Time: not-a-parsable-time-stampZ",
+			"SET timestamp=1459470669;",
+			"SELECT * FROM (SELECT  T1.orderNumber,  STATUS,  SUM(quantityOrdered * priceEach) AS  total FROM orders WHERE total > 1000 AS T1 INNER JOIN orderdetails AS T2 ON T1.orderNumber = T2.orderNumber GROUP BY  orderNumber) T WHERE total > 100;",
 		},
 		sq: SlowQuery{
-			Timestamp:       t2,
-			UnixTime:        1459470669,
 			Query:           "SELECT * FROM (SELECT  T1.orderNumber,  STATUS,  SUM(quantityOrdered * priceEach) AS  total FROM orders WHERE total > 1000 AS T1 INNER JOIN orderdetails AS T2 ON T1.orderNumber = T2.orderNumber GROUP BY  orderNumber) T WHERE total > 100",
 			NormalizedQuery: "select * from (select t1.ordernumber, status, sum(quantityordered * priceeach) as total from orders where total > ? as t1 inner join orderdetails as t2 on t1.ordernumber = t2.ordernumber group by ordernumber) t where total > ?",
 		},
+		timestamp: t1.Truncate(time.Second),
 	},
 	{
-		rawE: rawEvent{
-			lines: []string{
-				"# Time: not-a-parsable-time-stampZ",
-				"SET timestamp=1459470669;",
-				"SELECT * FROM orders WHERE total > 1000;",
-			},
+		rawE: []string{
+			"# Time: not-a-parsable-time-stampZ",
+			"SET timestamp=1459470669;",
+			"SELECT * FROM orders WHERE total > 1000;",
 		},
 		sq: SlowQuery{
-			Timestamp:       t2,
-			UnixTime:        1459470669,
 			Query:           "SELECT * FROM orders WHERE total > 1000",
 			NormalizedQuery: "select * from orders where total > ?",
 			Tables:          "orders",


### PR DESCRIPTION
adds `normalized_query`, `tables`, and `statement` columns to the dataset.

slow queries can span several lines, so as long we aren't matching other patterns keep building up the query until we get a ';'