### PR TITLE
add a config file to honeycomb

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,7 +86,6 @@ func main() {
 	flagParser := flag.NewParser(&options, flag.PrintErrors)
 	flagParser.Usage = "-p <parser> -k <writekey> -f </path/to/logfile> -d <mydata> [optional arguments]"
 
-	// parse flags and check for extra command line args
 	if extraArgs, err := flagParser.Parse(); err != nil || len(extraArgs) != 0 {
 		fmt.Println("Error: failed to parse the command line.")
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ var validParsers = []string{
 type GlobalOptions struct {
 	APIHost string `hidden:"true" long:"api_host" description:"Host for the Honeycomb API" default:"https://api.honeycomb.io/"`
 
-	ConfigFile string `short:"c" long:"config" description:"config file for honeytail in INI format. This flag should come first on the command line" default:"honeytail.conf" no-ini:"true"`
+	ConfigFile string `short:"c" long:"config" description:"config file for honeytail in INI format." no-ini:"true"`
 
 	SampleRate     uint `short:"r" long:"samplerate" description:"Only send 1 / N log lines" default:"1"`
 	NumSenders     uint `short:"P" long:"poolsize" description:"Number of concurrent connections to open to Honeycomb" default:"10"`
@@ -98,13 +98,15 @@ func main() {
 		os.Exit(1)
 	}
 	// read the config file if present
-	ini := flag.NewIniParser(flagParser)
-	ini.ParseAsDefaults = true
-	if err := ini.ParseFile(options.ConfigFile); err != nil {
-		fmt.Printf("Error: failed to parse the config file %s\n", options.ConfigFile)
-		fmt.Printf("\t%s\n", err)
-		usage()
-		os.Exit(1)
+	if options.ConfigFile != "" {
+		ini := flag.NewIniParser(flagParser)
+		ini.ParseAsDefaults = true
+		if err := ini.ParseFile(options.ConfigFile); err != nil {
+			fmt.Printf("Error: failed to parse the config file %s\n", options.ConfigFile)
+			fmt.Printf("\t%s\n", err)
+			usage()
+			os.Exit(1)
+		}
 	}
 
 	rand.Seed(time.Now().UnixNano())


### PR DESCRIPTION
Make it possible to configure honeytail using a config file instead of command line flags. 

For a sample config file, run ./honeytail --write_default_config > ./default_honeytail_config.ini

To convert an existing honeytail command line to a config file, add --write_current_config to the command line and save the output.