### PR TITLE
fix mysql line -> event splitting

### DIFF
--- a/parsers/mysql/mysql.go
+++ b/parsers/mysql/mysql.go
@@ -267,16 +267,11 @@ func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event) {
 	go p.handleEvents(rawEvents, send)
 
 	// flag to indicate when we've got a complete event to send
-	var sendEvent bool
 	var foundStatement bool
 	groupedLines := make([]string, 0, 5)
 	for line := range lines {
-		if foundStatement && strings.HasPrefix(line, "# ") && len(groupedLines) > 0 {
+		if foundStatement && len(groupedLines) > 0 && strings.HasPrefix(line, "# ") {
 			// we've started a new event. Send the previous one.
-			sendEvent = true
-		}
-		if sendEvent {
-			sendEvent = false
 			foundStatement = false
 			rawEvents <- groupedLines
 			groupedLines = make([]string, 0, 5)

--- a/parsers/mysql/mysql.go
+++ b/parsers/mysql/mysql.go
@@ -298,6 +298,10 @@ func (p *Parser) handleEvents(rawEvents <-chan []string, send chan<- event.Event
 		if len(sq) == 0 {
 			continue
 		}
+		if _, ok := sq["query"]; !ok {
+			// skip events with no query field
+			continue
+		}
 		if p.hostedOn != "" {
 			sq[hostedOnKey] = p.hostedOn
 		}

--- a/parsers/mysql/mysql_test.go
+++ b/parsers/mysql/mysql_test.go
@@ -441,6 +441,39 @@ func TestProcessLines(t *testing.T) {
 				},
 			},
 		},
+		{ // statement blocks with no query should be skipped
+			[]string{
+				"# Time: 151008  0:31:04",
+				"# User@Host: rails[rails] @  [10.252.9.33]",
+				"# Query_time: 0.030974  Lock_time: 0.000019 Rows_sent: 0  Rows_examined: 30259",
+				"SET timestamp=1444264264;",
+				"# User@Host: rails[rails] @  [10.252.9.33]",
+				"# Query_time: 0.002280  Lock_time: 0.000023 Rows_sent: 0  Rows_examined: 921",
+				"SET timestamp=1444264264;",
+				"SELECT `certs`.* FROM `certs` WHERE (`certs`.app_id = 993089) LIMIT 1;",
+				"# User@Host: rails[rails] @  [10.252.9.33]",
+				"# Query_time: 0.002280  Lock_time: 0.000023 Rows_sent: 0  Rows_examined: 921",
+				"SET timestamp=1444264264;",
+			},
+			[]event.Event{
+				{
+					Timestamp: time.Unix(1444264264, 0), // should pick up the SET timestamp=... cmd
+					Data: map[string]interface{}{
+						"client":           "",
+						"client_ip":        "10.252.9.33",
+						"user":             "rails",
+						"query_time":       0.002280,
+						"lock_time":        0.000023,
+						"rows_sent":        0,
+						"rows_examined":    921,
+						"query":            "SELECT `certs`.* FROM `certs` WHERE (`certs`.app_id = 993089) LIMIT 1",
+						"normalized_query": "select `certs`.* from `certs` where (`certs`.app_id = ?) limit ?",
+						"tables":           "certs",
+						"statement":        "select",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tsts {


### PR DESCRIPTION
Adjust logic for splitting mysql events to force finding at least one non-comment before finding a comment indicates that an event is complete