### PR TITLE
add detection of mysql headers that rds puts into the slow query log. end events when we see them, but otherwise ignore.

### DIFF
--- a/parsers/mysql/mysql_test.go
+++ b/parsers/mysql/mysql_test.go
@@ -433,6 +433,31 @@ var sqds = []slowQueryData{
 		},
 		timestamp: time.Unix(1364506803, 0),
 	},
+	{ /* 22 */
+		rawE: []string{
+			"# User@Host: rdsadmin[rdsadmin] @ localhost [127.0.0.1]  Id:     1",
+			"# Query_time: 0.000439  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 0",
+			"SET timestamp=1476901800;",
+			"select @@session.tx_read_only;",
+			"/rdsdbbin/mysql/bin/mysqld, Version: 5.6.22-log (MySQL Community Server (GPL)). started with:",
+			"Tcp port: 3306  Unix socket: /tmp/mysql.sock",
+			"Time                 Id Command    Argument",
+		},
+		sq: map[string]interface{}{
+			userKey:            "rdsadmin",
+			clientKey:          "localhost",
+			clientIPKey:        "127.0.0.1",
+			queryTimeKey:       0.000439,
+			lockTimeKey:        0.0,
+			rowsSentKey:        1,
+			rowsExaminedKey:    0,
+			queryKey:           "select @@session.tx_read_only",
+			normalizedQueryKey: "select @@session.tx_read_only",
+			statementKey:       "select",
+			tablesKey:          "@@session",
+		},
+		timestamp: time.Unix(1476901800, 0),
+	},
 }
 
 func TestHandleEvent(t *testing.T) {


### PR DESCRIPTION
according to http://dba.stackexchange.com/questions/56945/why-is-my-rds-mysql-slow-query-log-full-of-server-restarts rds inserts the headers whenever logs are flushed.

For now just ignore the lines (in the future it might be useful to track the version of mysql?) except to treat them as ending the previous event (same as we do for comment lines now.)