### PR TITLE
Add periodic status lines for file tailing stats and parsing stats

### DIFF
--- a/leash.go
+++ b/leash.go
@@ -138,6 +138,7 @@ func run(options GlobalOptions) {
 	// when exiting early
 	for _, hny := range hnys {
 		hny.tailer.LogStats()
+		hny.parser.LogStats()
 		hny.rStats.logAndReset()
 	}
 
@@ -416,6 +417,7 @@ func logStats(hny *hny, interval uint) {
 	ticker := time.NewTicker(time.Second * time.Duration(interval))
 	for range ticker.C {
 		hny.tailer.LogStats()
+		hny.parser.LogStats()
 		hny.rStats.logAndReset()
 	}
 }

--- a/parsers/parsers.go
+++ b/parsers/parsers.go
@@ -12,4 +12,6 @@ type Parser interface {
 	// ProcessLines consumes log lines from the lines channel and sends log events
 	// to the send channel.
 	ProcessLines(lines <-chan string, send chan<- event.Event)
+	// log something about the parser's statistics (eg num events parsed)
+	LogStats()
 }

--- a/tail/tail.go
+++ b/tail/tail.go
@@ -59,6 +59,7 @@ type State struct {
 	INode         uint64 // the inode
 	Offset        int64
 	Stat          unix.Stat_t `json:"-"`
+	TrailingBy    int64       `json:"-"`
 }
 
 type Tailer struct {
@@ -77,6 +78,7 @@ func (t *Tailer) LogStats() {
 		"length":        t.state.Stat.Size,
 		"lines_read":    t.linesRead,
 		"lines_errored": t.linesErrored,
+		"bytes_behind":  t.state.TrailingBy,
 	}).Info("Logfile Tail Status")
 	t.resetStats()
 }
@@ -371,5 +373,6 @@ func (t *Tailer) updateStats(fileTailer *tail.Tail) error {
 		return err
 	}
 	t.state.Offset = currentPos
+	t.state.TrailingBy = t.state.Stat.Size - currentPos
 	return nil
 }


### PR DESCRIPTION
Add in one last printout of the stats when honeytail finishes.  This is a huge help when parsing short files with --tail.stop and honeytail says "All done" and you wonder "what happened?".

Add in stats from file tailing (how many lines, how many errors, how far behind the tip of the file) and parsing (whatever the parsing module exports, but likely counting lines and events and parsing errors).