### PR TITLE
Better identify honeytail usage by including the parser in the user-agent header

### DIFF
--- a/leash_test.go
+++ b/leash_test.go
@@ -182,19 +182,19 @@ func TestSetVersion(t *testing.T) {
 	run(opts)
 	userAgent := ts.rsp.req.Header.Get("User-Agent")
 	testEquals(t, userAgent, "libhoney-go/1.1.2")
-	setVersion(false)
+	setVersionUserAgent(false, "fancyParser")
 	run(opts)
 	userAgent = ts.rsp.req.Header.Get("User-Agent")
-	testEquals(t, userAgent, "libhoney-go/1.1.2 honeytail/dev")
+	testEquals(t, userAgent, "libhoney-go/1.1.2 honeytail/dev (fancyParser)")
 	BuildID = "test"
-	setVersion(false)
+	setVersionUserAgent(false, "fancyParser")
 	run(opts)
 	userAgent = ts.rsp.req.Header.Get("User-Agent")
-	testEquals(t, userAgent, "libhoney-go/1.1.2 honeytail/test")
-	setVersion(true)
+	testEquals(t, userAgent, "libhoney-go/1.1.2 honeytail/test (fancyParser)")
+	setVersionUserAgent(true, "fancyParser")
 	run(opts)
 	userAgent = ts.rsp.req.Header.Get("User-Agent")
-	testEquals(t, userAgent, "libhoney-go/1.1.2 honeytail/test backfill")
+	testEquals(t, userAgent, "libhoney-go/1.1.2 honeytail/test (fancyParser backfill)")
 }
 
 func TestDropField(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -130,7 +130,7 @@ func main() {
 		options.Tail.Stop = true
 	}
 
-	setVersion(options.Backfill)
+	setVersionUserAgent(options.Backfill, options.Reqs.ParserName)
 	handleOtherModes(flagParser, options.Modes)
 	addParserDefaultOptions(&options)
 	sanityCheckOptions(&options)
@@ -140,16 +140,16 @@ func main() {
 }
 
 // setVersion sets the internal version ID and updates libhoney's user-agent
-func setVersion(backfill bool) {
+func setVersionUserAgent(backfill bool, parserName string) {
 	if BuildID == "" {
 		version = "dev"
 	} else {
 		version = BuildID
 	}
 	if backfill {
-		version += " backfill"
+		parserName += " backfill"
 	}
-	libhoney.UserAgentAddition = fmt.Sprintf("honeytail/%s", version)
+	libhoney.UserAgentAddition = fmt.Sprintf("honeytail/%s (%s)", version, parserName)
 }
 
 // handleOtherModes takse care of all flags that say we should just do something


### PR DESCRIPTION
Also follow better user-agent syntax by putting the comment in parentheses.