### PR TITLE
Build deb and rpm packages for honeytail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,13 @@ go:
 
 script: go test github.com/honeycombio/honeytail/...
 
+before_install:
+    - sudo apt-get -qq update
+    - sudo apt-get install -y ruby-dev build-essential
+    - sudo gem install fpm
+
 after_success:
     - rm $GOPATH/bin/honeytail
     - go install -ldflags "-X main.BuildID=1.${TRAVIS_BUILD_NUMBER}" github.com/honeycombio/honeytail/...
+    - ./build-pkg.sh -v "1.${TRAVIS_BUILD_NUMBER}" -t deb
+    - ./build-pkg.sh -v "1.${TRAVIS_BUILD_NUMBER}" -t rpm

--- a/build-pkg.sh
+++ b/build-pkg.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Build deb or rpm packages for honeytail.
+set -e
+
+function usage() {
+    echo "Usage: build-pkg.sh -v <version> -t <package_type>"
+    exit 2
+}
+
+while getopts "v:t:" opt; do
+    case "$opt" in
+    v)
+        version=$OPTARG
+        ;;
+    t)
+        pkg_type=$OPTARG
+        ;;
+    esac
+done
+
+if [ -z "$version" ] || [ -z "$pkg_type" ]; then
+    usage
+fi
+
+fpm -s dir -n honeytail -C $GOPATH/bin \
+    -m "Honeycomb <team@honeycomb.io>" \
+    -p $GOPATH/bin \
+    -v $version \
+    -t $pkg_type \
+    ./honeytail=/usr/bin/honeytail


### PR DESCRIPTION
This packaging is very simple: it just drops the honeytail binary into
/usr/bin/. Later, we can add init scripts and so on.