### PR TITLE
Add the packaging metadata to build the honeytail snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: honeytail
+version: master
+summary: debug complex systems
+description: |
+  honeytail is Honeycomb's agent for ingesting log file data into Honeycomb
+  and making it available for exploration. Its favorite format is JSON, but
+  understands how to parse a range of other well-known log formats.
+
+
+grade: devel
+confinement: classic
+
+apps:
+  honeytail:
+    command: honeytail
+
+parts:
+  honeytail:
+    source: .
+    plugin: go
+    go-importpath: github.com/honeycombio/honeytail


### PR DESCRIPTION
This is a package for the installation of apps that works in most Linux distributions.
Landing it upstream will enable builds that then can be distributed to many users through the Ubuntu store.