### PR TITLE
Add upstart configs and default config to honeytail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,6 @@ before_install:
 after_success:
     - rm $GOPATH/bin/honeytail
     - go install -ldflags "-X main.BuildID=1.${TRAVIS_BUILD_NUMBER}" github.com/honeycombio/honeytail/...
+    - $GOPATH/bin/honeytail --write_default_config > ./honeytail.conf
     - ./build-pkg.sh -v "1.${TRAVIS_BUILD_NUMBER}" -t deb
     - ./build-pkg.sh -v "1.${TRAVIS_BUILD_NUMBER}" -t rpm

--- a/build-pkg.sh
+++ b/build-pkg.sh
@@ -23,9 +23,11 @@ if [ -z "$version" ] || [ -z "$pkg_type" ]; then
     usage
 fi
 
-fpm -s dir -n honeytail -C $GOPATH/bin \
+fpm -s dir -n honeytail \
     -m "Honeycomb <team@honeycomb.io>" \
     -p $GOPATH/bin \
     -v $version \
     -t $pkg_type \
-    ./honeytail=/usr/bin/honeytail
+    $GOPATH/bin/honeytail=/usr/bin/honeytail \
+    ./honeytail.upstart=/etc/init/honeytail.conf \
+    ./honeytail.conf=/etc/honeytail/honeytail.conf

--- a/honeytail.upstart
+++ b/honeytail.upstart
@@ -1,0 +1,12 @@
+# Upstart job for honeytail, the log tailer for Honeycomb
+# https://honeycomb.io/
+
+description     "Honeytail Daemon"
+author          "Ben Hartshorne <ben@honeycomb.io>"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+
+exec /usr/bin/honeytail -c /etc/honeytail/honeytail.conf


### PR DESCRIPTION
Install an upstart config and default config file.  The upstart will fail unless you overwrite the config file with valid values (it will fail to spawn honeytail because there's no parser)