### PR TITLE
Run honeytail as service user, not root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,17 @@ dist: trusty
 go:
     - 1.6
 
-script: go test github.com/honeycombio/honeytail/...
+script:
+    - set -e
+# Run tests
+    - go test github.com/honeycombio/honeytail/...
+# Build binary and packages
+    - go install -ldflags "-X main.BuildID=1.${TRAVIS_BUILD_NUMBER}" github.com/honeycombio/honeytail/...
+    - $GOPATH/bin/honeytail --write_default_config > ./honeytail.conf
+    - ./build-pkg.sh -v "1.${TRAVIS_BUILD_NUMBER}" -t deb
+    - ./build-pkg.sh -v "1.${TRAVIS_BUILD_NUMBER}" -t rpm
+# Check that packages install
+    - pkg-test/test.sh "1.${TRAVIS_BUILD_NUMBER}"
 
 before_install:
     # Install fpm for deb/rpm package building
@@ -24,10 +34,3 @@ before_install:
 
 install:
         - true # HACK: fixes travis-CI lack of support for vendor/ + godeps
-
-after_success:
-    - rm $GOPATH/bin/honeytail
-    - go install -ldflags "-X main.BuildID=1.${TRAVIS_BUILD_NUMBER}" github.com/honeycombio/honeytail/...
-    - $GOPATH/bin/honeytail --write_default_config > ./honeytail.conf
-    - ./build-pkg.sh -v "1.${TRAVIS_BUILD_NUMBER}" -t deb
-    - ./build-pkg.sh -v "1.${TRAVIS_BUILD_NUMBER}" -t rpm

--- a/build-pkg.sh
+++ b/build-pkg.sh
@@ -28,6 +28,7 @@ fpm -s dir -n honeytail \
     -p $GOPATH/bin \
     -v $version \
     -t $pkg_type \
+    --pre-install=./preinstall \
     $GOPATH/bin/honeytail=/usr/bin/honeytail \
     ./honeytail.upstart=/etc/init/honeytail.conf \
     ./honeytail.service=/lib/systemd/system/honeytail.service \

--- a/honeytail.service
+++ b/honeytail.service
@@ -6,6 +6,8 @@ After=network.target
 ExecStart=/usr/bin/honeytail -c /etc/honeytail/honeytail.conf
 KillMode=process
 Restart=on-failure
+User=honeycomb
+Group=honeycomb
 
 [Install]
 Alias=honeytail honeytail.service

--- a/honeytail.upstart
+++ b/honeytail.upstart
@@ -9,4 +9,4 @@ stop on runlevel [!2345]
 
 respawn
 
-exec /usr/bin/honeytail -c /etc/honeytail/honeytail.conf
+exec su -s /bin/sh -c 'exec "$0" "$@"' honeycomb -- /usr/bin/honeytail -c /etc/honeytail/honeytail.conf

--- a/pkg-test/Dockerfile.deb
+++ b/pkg-test/Dockerfile.deb
@@ -1,0 +1,5 @@
+FROM ubuntu:14.04
+ARG package
+COPY $package .
+
+RUN dpkg -i $package

--- a/pkg-test/Dockerfile.rpm
+++ b/pkg-test/Dockerfile.rpm
@@ -1,0 +1,6 @@
+FROM centos:6
+
+ARG package
+COPY $package .
+
+RUN rpm -i $package

--- a/pkg-test/test.sh
+++ b/pkg-test/test.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Smoke-test package installation by installing packages into a container. This
+# assumes that packages exist in $GOPATH/bin
+
+set -e
+
+if [ "$#" -ne 1 ]; then echo "usage: test.sh <build id>"; exit 1; fi
+
+BUILDID=$1
+DEB=honeytail_${BUILDID}_amd64.deb
+RPM=honeytail-${BUILDID}-1.x86_64.rpm
+DIR=`dirname $0`
+echo docker build --build-arg package=$DEB -f Dockerfile.deb $DIR
+
+cp $GOPATH/bin/$DEB $DIR
+cp $GOPATH/bin/$RPM $DIR
+docker build --build-arg package=$DEB -f $DIR/Dockerfile.deb $DIR
+docker build --build-arg package=$RPM -f $DIR/Dockerfile.rpm $DIR

--- a/preinstall
+++ b/preinstall
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+USER="honeycomb"
+GROUP="honeycomb"
+
+# Create service group and user if they doesn't already exist
+if ! getent group $GROUP >/dev/null
+then
+    if type "groupadd" > /dev/null 2>&1; then
+        groupadd --system $GROUP >/dev/null
+    else
+        addgroup --system $GROUP >/dev/null
+    fi
+fi
+
+if ! getent passwd $USER >/dev/null
+then
+        useradd \
+          --system \
+          -g $GROUP \
+          --home /nonexistent \
+          --shell /bin/false \
+          $USER >/dev/null
+fi

--- a/preinstall
+++ b/preinstall
@@ -23,3 +23,5 @@ then
           --shell /bin/false \
           $USER >/dev/null
 fi
+
+usermod -a -G adm honeytail

--- a/preinstall
+++ b/preinstall
@@ -24,4 +24,4 @@ then
           $USER >/dev/null
 fi
 
-usermod -a -G adm honeytail
+usermod -a -G adm honeycomb


### PR DESCRIPTION
This patch creates a `honeycomb` service user in the package preinstall script,
and runs supervised honeytail as that user. We shouldn't need to be root.

Unfortunately this is a bit byzantine for upstart, because AWS Linux uses
an old version of upstart that doesn't support setuid. (At least one user has
previously reported running on AWS Linux). Oh well.

I tested this on Debian stable (systemd) and AWS Linux (upstart).