### PR TITLE
push sampling for mysql logs into the mysql parser

### DIFF
--- a/leash.go
+++ b/leash.go
@@ -113,9 +113,9 @@ func run(options GlobalOptions) {
 			close(realToBeSent)
 		}()
 
-		// start up the sender
-		go sendToLibhoney(realToBeSent, toBeResent, delaySending, doneSending,
-			options.TailSample)
+		// start up the sender. all sources are either sampled when tailing or in-
+		// parser, so always tell libhoney events are pre-sampled
+		go sendToLibhoney(realToBeSent, toBeResent, delaySending, doneSending, true)
 
 		// start a goroutine that reads from responses and logs.
 		responses := libhoney.Responses()
@@ -156,7 +156,9 @@ func getParserAndOptions(options GlobalOptions) (parsers.Parser, interface{}) {
 		parser = &mongodb.Parser{}
 		opts = &options.Mongo
 	case "mysql":
-		parser = &mysql.Parser{}
+		parser = &mysql.Parser{
+			SampleRate: int(options.SampleRate),
+		}
 		opts = &options.MySQL
 	case "arangodb":
 		parser = &arangodb.Parser{}

--- a/leash_test.go
+++ b/leash_test.go
@@ -405,24 +405,15 @@ func TestSampleRate(t *testing.T) {
 	testEquals(t, ts.rsp.reqBody, `{"format":"json49"}`)
 	sampleRate := ts.rsp.req.Header.Get("X-Honeycomb-Samplerate")
 	testEquals(t, sampleRate, "1")
-
 	ts.rsp.reset()
+
 	opts.SampleRate = 3
-	run(opts)
-	// setting a sample rate of 3 and a rand seed of 1, 16 requests.
-	// libhoney does the sampling
-	testEquals(t, ts.rsp.reqCounter, 16)
-	testEquals(t, ts.rsp.reqBody, `{"format":"json47"}`)
-	sampleRate = ts.rsp.req.Header.Get("X-Honeycomb-Samplerate")
-	testEquals(t, sampleRate, "3")
-	ts.rsp.reset()
-
 	opts.TailSample = true
 	run(opts)
 	// setting a sample rate of 3 gets 17 requests.
 	// tail does the sampling
 	testEquals(t, ts.rsp.reqCounter, 17)
-	testEquals(t, ts.rsp.reqBody, `{"format":"json40"}`)
+	testEquals(t, ts.rsp.reqBody, `{"format":"json49"}`)
 	sampleRate = ts.rsp.req.Header.Get("X-Honeycomb-Samplerate")
 	testEquals(t, sampleRate, "3")
 }

--- a/main.go
+++ b/main.go
@@ -192,7 +192,8 @@ func addParserDefaultOptions(options *GlobalOptions) {
 		options.RequestShape = append(options.RequestShape, "request")
 	}
 	if options.Reqs.ParserName != "mysql" {
-		// mysql is the only parser that requires post-parsed sampling.
+		// mysql is the only parser that requires in-parser sampling because it has
+		// a multi-line log format.
 		// Sample all other parser when tailing to conserve CPU
 		options.TailSample = true
 	} else {

--- a/parsers/mysql/mysql.go
+++ b/parsers/mysql/mysql.go
@@ -336,14 +336,8 @@ func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, pref
 			if foundStatement {
 				// we've started a new event. Send the previous one.
 				foundStatement = false
-				// if sampling is enabled, drop events here to conserve parsing CPU
-				if p.SampleRate > 1 {
-					if rand.Intn(p.SampleRate) == 0 {
-						// keep this event
-						rawEvents <- groupedLines
-					}
-				} else {
-					// sampling is not enabled
+				// if sampling is disabled or sampler says keep, pass along this group.
+				if p.SampleRate <= 1 || rand.Intn(p.SampleRate) == 0 {
 					rawEvents <- groupedLines
 				}
 				groupedLines = make([]string, 0, 5)
@@ -353,13 +347,8 @@ func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, pref
 	}
 	// send the last event, if there was one collected
 	if foundStatement {
-		if p.SampleRate > 1 {
-			if rand.Intn(p.SampleRate) == 0 {
-				// keep this event
-				rawEvents <- groupedLines
-			}
-		} else {
-			// sampling is not enabled
+		// if sampling is disabled or sampler says keep, pass along this group.
+		if p.SampleRate <= 1 || rand.Intn(p.SampleRate) == 0 {
 			rawEvents <- groupedLines
 		}
 	}


### PR DESCRIPTION
Instead of relying on libhoney's sampling, have the mysql parser do it to avoid wasting an enormous amount of CPU parsing lines we're just going to throw away.