### PR TITLE
Add flag to keyval parser to filter incoming mesasge stream

### DIFF
--- a/parsers/keyval/keyval.go
+++ b/parsers/keyval/keyval.go
@@ -121,13 +121,20 @@ func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, pref
 		}
 
 		parsedLine, err := p.lineParser.ParseLine(line)
-
 		if err != nil {
 			// skip lines that won't parse
 			logrus.WithFields(logrus.Fields{
 				"line":  line,
 				"error": err,
 			}).Debug("skipping line; failed to parse.")
+			continue
+		}
+		if len(parsedLine) == 0 {
+			// skip empty lines, as determined by the parser
+			logrus.WithFields(logrus.Fields{
+				"line":  line,
+				"error": err,
+			}).Debug("skipping line; no key/val pairs found.")
 			continue
 		}
 		// merge the prefix fields and the parsed line contents

--- a/parsers/keyval/keyval.go
+++ b/parsers/keyval/keyval.go
@@ -50,7 +50,10 @@ func (r *RealNower) Now() time.Time {
 func (p *Parser) Init(options interface{}) error {
 	p.conf = *options.(*Options)
 	if p.conf.FilterRegex != "" {
-		p.filterRegex = regexp.MustCompile(p.conf.FilterRegex)
+		var err error
+		if p.filterRegex, err = regexp.Compile(p.conf.FilterRegex); err != nil {
+			return err
+		}
 	}
 
 	p.nower = &RealNower{}
@@ -247,4 +250,14 @@ func (p *Parser) warnAboutTime(fieldName string, foundTimeVal interface{}, msg s
 	}
 	logrus.WithField("time_field", fieldName).WithField("time_value", foundTimeVal).Warn(msg + "\n  Please refer to https://honeycomb.io/docs/json#timestamp-parsing")
 	p.warnedAboutTime = true
+}
+
+type NoopLineParser struct {
+	incomingLine string
+	outgoingMap  map[string]interface{}
+}
+
+func (n *NoopLineParser) ParseLine(line string) (map[string]interface{}, error) {
+	n.incomingLine = line
+	return n.outgoingMap, nil
 }

--- a/parsers/keyval/keyval.go
+++ b/parsers/keyval/keyval.go
@@ -143,7 +143,7 @@ func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, pref
 			logrus.WithFields(logrus.Fields{
 				"line":  line,
 				"error": err,
-			}).Debug("skipping line; no all values are the empty string.")
+			}).Debug("skipping line; all values are the empty string.")
 			continue
 		}
 		// merge the prefix fields and the parsed line contents

--- a/parsers/keyval/keyval.go
+++ b/parsers/keyval/keyval.go
@@ -99,7 +99,8 @@ func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, pref
 		// if matching regex is set, filter lines here
 		if p.filterRegex != nil {
 			matched := p.filterRegex.MatchString(line)
-			if matched && !p.conf.InvertFilter {
+			// if both are true or both are false, skip. else continue
+			if matched == p.conf.InvertFilter {
 				logrus.WithFields(logrus.Fields{
 					"line":    line,
 					"matched": matched,


### PR DESCRIPTION
All other parsers have strict conditions under which they'll try and parse a line.  The keyval parser doesn't, and so extra lines in the log file (that don't have a key=val format) cause extra fields to be created, to disastrous effect. 
This change adds a flag to let you specify a regular expression to require that only matching lines get parsed or, when the inverse flag is added, to parse all lines except those that match.