### PR TITLE
thicken pipe between the the parser and libhoney, enable multilpe parallel parsers

### DIFF
--- a/leash.go
+++ b/leash.go
@@ -210,47 +210,39 @@ func getParserAndOptions(options GlobalOptions) (parsers.Parser, interface{}) {
 // returns a channel on which it will send the munged events.
 // It is responsible for hashing or dropping or adding fields to the events
 func modifyEventContents(toBeSent chan event.Event, options GlobalOptions) chan event.Event {
-	for _, field := range options.DropFields {
-		toBeSent = dropEventField(field, toBeSent, options)
+	// short circuit this if no field scrubbing is enabled
+	if len(options.DropFields) == 0 && len(options.ScrubFields) == 0 &&
+		len(options.AddFields) == 0 && len(options.RequestShape) == 0 {
+		return toBeSent
 	}
-	for _, field := range options.ScrubFields {
-		toBeSent = scrubEventField(field, toBeSent, options)
-	}
-	for _, field := range options.AddFields {
-		toBeSent = addEventField(field, toBeSent, options)
-	}
-	for _, field := range options.RequestShape {
-		toBeSent = requestShape(field, toBeSent, options)
-	}
-	return toBeSent
-}
-
-// dropEventField drops any fields that are to be dropped, drop them before
-// passing the event on down the line to the next consumer
-func dropEventField(field string, toBeSent chan event.Event, options GlobalOptions) chan event.Event {
-	newSent := make(chan event.Event, options.NumSenders)
-	go func() {
-		wg := sync.WaitGroup{}
-		for i := uint(0); i < options.NumSenders; i++ {
-			wg.Add(1)
-			go func() {
-				for ev := range toBeSent {
-					delete(ev.Data, field)
-					newSent <- ev
-				}
-				wg.Done()
-			}()
+	// parse the addField bit once instead of for every event
+	parsedAddFields := map[string]string{}
+	for _, addField := range options.AddFields {
+		splitField := strings.SplitN(addField, "=", 2)
+		if len(splitField) != 2 {
+			logrus.WithFields(logrus.Fields{
+				"add_field": addField,
+			}).Fatal("unable to separate provided field into a key=val pair")
 		}
-		wg.Wait()
-		close(newSent)
-	}()
-	return newSent
-}
-
-// scrubEventField replaces the value for  any fields that are to be scrubbed
-// with a sha256 hash of the value, then passes the event on down the line to
-// the next consumer
-func scrubEventField(field string, toBeSent chan event.Event, options GlobalOptions) chan event.Event {
+		parsedAddFields[splitField[0]] = splitField[1]
+	}
+	// do all the advance work for request shaping
+	shaper := &requestShaper{}
+	if len(options.RequestShape) != 0 {
+		shaper.pr = &urlshaper.Parser{}
+		if options.ShapePrefix != "" {
+			shaper.prefix = options.ShapePrefix + "_"
+		}
+		for _, rpat := range options.RequestPattern {
+			pat := urlshaper.Pattern{Pat: rpat}
+			if err := pat.Compile(); err != nil {
+				logrus.WithField("request_pattern", rpat).WithError(err).Fatal(
+					"Failed to compile provided pattern.")
+			}
+			shaper.pr.Patterns = append(shaper.pr.Patterns, &pat)
+		}
+	}
+	// ok, we need to munge events. Sing up enough goroutines to handle this
 	newSent := make(chan event.Event, options.NumSenders)
 	go func() {
 		wg := sync.WaitGroup{}
@@ -258,13 +250,24 @@ func scrubEventField(field string, toBeSent chan event.Event, options GlobalOpti
 			wg.Add(1)
 			go func() {
 				for ev := range toBeSent {
-					if val, ok := ev.Data[field]; ok {
-						// generate a sha256 hash
-						newVal := sha256.Sum256([]byte(fmt.Sprintf("%v", val)))
-						// and use the base16 string version of it
-						ev.Data[field] = fmt.Sprintf("%x", newVal)
+					for _, field := range options.DropFields {
+						delete(ev.Data, field)
+					}
+					for _, field := range options.ScrubFields {
+						if val, ok := ev.Data[field]; ok {
+							// generate a sha256 hash and use the base16 for the content
+							newVal := sha256.Sum256([]byte(fmt.Sprintf("%v", val)))
+							ev.Data[field] = fmt.Sprintf("%x", newVal)
+						}
+					}
+					for k, v := range parsedAddFields {
+						ev.Data[k] = v
+					}
+					for _, field := range options.RequestShape {
+						shaper.requestShape(field, &ev, options)
 					}
 					newSent <- ev
+
 				}
 				wg.Done()
 			}()
@@ -275,118 +278,62 @@ func scrubEventField(field string, toBeSent chan event.Event, options GlobalOpti
 	return newSent
 }
 
-// addEventField adds any fields that are to be added to the event before
-// passing the event on down the line to the next consumer
-func addEventField(field string, toBeSent chan event.Event, options GlobalOptions) chan event.Event {
-	newSent := make(chan event.Event, options.NumSenders)
-	// separate the k=v field we got from the command line
-	splitField := strings.SplitN(field, "=", 2)
-	if len(splitField) != 2 {
-		logrus.WithFields(logrus.Fields{
-			"add_field": field,
-		}).Fatal("unable to separate provided field into a key=val pair")
-	}
-	key := splitField[0]
-	val := splitField[1]
-	go func() {
-		wg := sync.WaitGroup{}
-		for i := uint(0); i < options.NumSenders; i++ {
-			wg.Add(1)
-			go func() {
-				for ev := range toBeSent {
-					ev.Data[key] = val
-					newSent <- ev
-				}
-				wg.Done()
-			}()
-		}
-		wg.Wait()
-		close(newSent)
-	}()
-	return newSent
+// requestShaper holds the bits about request shaping that want to be
+// precompiled instead of compute on every event
+type requestShaper struct {
+	prefix string
+	pr     *urlshaper.Parser
 }
 
 // requestShape expects the field passed in to have the form
 // VERB /path/of/request HTTP/1.x
 // If it does, it will break it apart into components, normalize the URL,
 // and add a handful of additional fields based on what it finds.
-func requestShape(field string, toBeSent chan event.Event, options GlobalOptions) chan event.Event {
-	logrus.WithFields(logrus.Fields{
-		"field": field,
-	}).Debug("spinning up request shaper")
-	newSent := make(chan event.Event, options.NumSenders)
-	var prefix string
-	if options.ShapePrefix != "" {
-		prefix = options.ShapePrefix + "_"
-	}
-	pr := urlshaper.Parser{}
-	for _, rpat := range options.RequestPattern {
-		pat := urlshaper.Pattern{Pat: rpat}
-		if err := pat.Compile(); err != nil {
-			logrus.WithField("request_pattern", rpat).WithError(err).Fatal(
-				"Failed to compile provided pattern.")
+func (r *requestShaper) requestShape(field string, ev *event.Event,
+	options GlobalOptions) {
+	if val, ok := ev.Data[field]; ok {
+		// start by splitting out method, uri, and version
+		parts := strings.Split(val.(string), " ")
+		var path string
+		if len(parts) == 3 {
+			// treat it as METHOD /path HTTP/1.X
+			ev.Data[r.prefix+field+"_method"] = parts[0]
+			ev.Data[r.prefix+field+"_protocol_version"] = parts[2]
+			path = parts[1]
+		} else {
+			// treat it as just the /path
+			path = parts[0]
 		}
-		pr.Patterns = append(pr.Patterns, &pat)
-	}
-	go func() {
-		wg := sync.WaitGroup{}
-		for i := uint(0); i < options.NumSenders; i++ {
-			wg.Add(1)
-			go func() {
-				for ev := range toBeSent {
-					if val, ok := ev.Data[field]; ok {
-						// start by splitting out method, uri, and version
-						parts := strings.Split(val.(string), " ")
-						var path string
-						if len(parts) == 3 {
-							// treat it as METHOD /path HTTP/1.X
-							ev.Data[prefix+field+"_method"] = parts[0]
-							ev.Data[prefix+field+"_protocol_version"] = parts[2]
-							path = parts[1]
-						} else {
-							// treat it as just the /path
-							path = parts[0]
-						}
-						// next up, get all the goodies out of the path
-						res, err := pr.Parse(path)
-						if err != nil {
-							// couldn't parse it, just pass along the event
-							newSent <- ev
-							continue
-						}
-						ev.Data[prefix+field+"_uri"] = res.URI
-						ev.Data[prefix+field+"_path"] = res.Path
-						if res.Query != "" {
-							ev.Data[prefix+field+"_query"] = res.Query
-						}
-						for k, v := range res.QueryFields {
-							// only include the keys we want
-							if options.RequestParseQuery == "all" ||
-								whitelistKey(options.RequestQueryKeys, k) {
-								if len(v) > 1 {
-									sort.Strings(v)
-								}
-								ev.Data[prefix+field+"_query_"+k] = strings.Join(v, ", ")
-							}
-						}
-						for k, v := range res.PathFields {
-							ev.Data[prefix+field+"_path_"+k] = v[0]
-						}
-						ev.Data[prefix+field+"_shape"] = res.Shape
-						ev.Data[prefix+field+"_pathshape"] = res.PathShape
-						if res.QueryShape != "" {
-							ev.Data[prefix+field+"_queryshape"] = res.QueryShape
-						}
-					}
-					newSent <- ev
+		// next up, get all the goodies out of the path
+		res, err := r.pr.Parse(path)
+		if err != nil {
+			// couldn't parse it, just pass along the event
+			return
+		}
+		ev.Data[r.prefix+field+"_uri"] = res.URI
+		ev.Data[r.prefix+field+"_path"] = res.Path
+		if res.Query != "" {
+			ev.Data[r.prefix+field+"_query"] = res.Query
+		}
+		for k, v := range res.QueryFields {
+			// only include the keys we want
+			if options.RequestParseQuery == "all" ||
+				whitelistKey(options.RequestQueryKeys, k) {
+				if len(v) > 1 {
+					sort.Strings(v)
 				}
-				wg.Done()
-			}()
+				ev.Data[r.prefix+field+"_query_"+k] = strings.Join(v, ", ")
+			}
 		}
-		wg.Wait()
-		close(newSent)
-	}()
-	return newSent
+		for k, v := range res.PathFields {
+			ev.Data[r.prefix+field+"_path_"+k] = v[0]
+		}
+		ev.Data[r.prefix+field+"_shape"] = res.Shape
+		ev.Data[r.prefix+field+"_pathshape"] = res.PathShape
+		if res.QueryShape != "" {
+			ev.Data[r.prefix+field+"_queryshape"] = res.QueryShape
+		}
+	}
 }
 
 // return true if the key is in the whitelist

--- a/leash.go
+++ b/leash.go
@@ -184,12 +184,15 @@ func getParserAndOptions(options GlobalOptions) (parsers.Parser, interface{}) {
 	case "nginx":
 		parser = &nginx.Parser{}
 		opts = &options.Nginx
+		opts.(*nginx.Options).NumParsers = int(options.NumSenders)
 	case "json":
 		parser = &htjson.Parser{}
 		opts = &options.JSON
+		opts.(*htjson.Options).NumParsers = int(options.NumSenders)
 	case "keyval":
 		parser = &keyval.Parser{}
 		opts = &options.KeyVal
+		opts.(*keyval.Options).NumParsers = int(options.NumSenders)
 	case "mongo", "mongodb":
 		parser = &mongodb.Parser{}
 		opts = &options.Mongo
@@ -199,6 +202,7 @@ func getParserAndOptions(options GlobalOptions) (parsers.Parser, interface{}) {
 			SampleRate: int(options.SampleRate),
 		}
 		opts = &options.MySQL
+		opts.(*mysql.Options).NumParsers = int(options.NumSenders)
 	case "arangodb":
 		parser = &arangodb.Parser{}
 		opts = &options.ArangoDB

--- a/leash.go
+++ b/leash.go
@@ -193,6 +193,7 @@ func getParserAndOptions(options GlobalOptions) (parsers.Parser, interface{}) {
 	case "mongo", "mongodb":
 		parser = &mongodb.Parser{}
 		opts = &options.Mongo
+		opts.(*mongodb.Options).NumParsers = int(options.NumSenders)
 	case "mysql":
 		parser = &mysql.Parser{
 			SampleRate: int(options.SampleRate),

--- a/leash_test.go
+++ b/leash_test.go
@@ -360,7 +360,7 @@ func TestRequestShapeRaw(t *testing.T) {
 	// test whitelisting keys foo, baz, and bend but not bar
 	opts.RequestQueryKeys = []string{"foo", "baz", "bend"}
 	tbs := make(chan event.Event)
-	output := requestShape(reqField, tbs, opts)
+	output := modifyEventContents(tbs, opts)
 	for input, expectedResult := range urlsWhitelistQuery {
 		ev := event.Event{
 			Data: map[string]interface{}{
@@ -381,7 +381,7 @@ func TestRequestShapeRaw(t *testing.T) {
 	// included
 	opts.RequestParseQuery = "all"
 	tbs = make(chan event.Event)
-	output = requestShape(reqField, tbs, opts)
+	output = modifyEventContents(tbs, opts)
 	for input, expectedResult := range urlsAllQuery {
 		ev := event.Event{
 			Data: map[string]interface{}{

--- a/parsers/htjson/htjson.go
+++ b/parsers/htjson/htjson.go
@@ -15,8 +15,6 @@ import (
 	"github.com/honeycombio/honeytail/parsers"
 )
 
-const numParsers = 20
-
 var possibleTimeFieldNames = []string{
 	"time", "Time",
 	"timestamp", "Timestamp", "TimeStamp",
@@ -27,6 +25,8 @@ var possibleTimeFieldNames = []string{
 type Options struct {
 	TimeFieldName string `long:"timefield" description:"Name of the field that contains a timestamp"`
 	Format        string `long:"format" description:"Format of the timestamp found in timefield (supports strftime and Golang time formats)"`
+
+	NumParsers int `hidden:"true" description:"number of mongo parsers to spin up"`
 }
 
 type Parser struct {
@@ -88,7 +88,7 @@ func (j *JSONLineParser) ParseLine(line string) (map[string]interface{}, error) 
 
 func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, prefixRegex *parsers.ExtRegexp) {
 	wg := sync.WaitGroup{}
-	for i := 0; i < numParsers; i++ {
+	for i := 0; i < p.conf.NumParsers; i++ {
 		wg.Add(1)
 		go func() {
 			for line := range lines {

--- a/parsers/htjson/htjson.go
+++ b/parsers/htjson/htjson.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -13,6 +14,8 @@ import (
 	"github.com/honeycombio/honeytail/event"
 	"github.com/honeycombio/honeytail/parsers"
 )
+
+const numParsers = 20
 
 var possibleTimeFieldNames = []string{
 	"time", "Time",
@@ -84,42 +87,51 @@ func (j *JSONLineParser) ParseLine(line string) (map[string]interface{}, error) 
 }
 
 func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, prefixRegex *parsers.ExtRegexp) {
-	for line := range lines {
-		logrus.WithFields(logrus.Fields{
-			"line": line,
-		}).Debug("Attempting to process json log line")
+	wg := sync.WaitGroup{}
+	for i := 0; i < numParsers; i++ {
+		wg.Add(1)
+		go func() {
+			for line := range lines {
+				logrus.WithFields(logrus.Fields{
+					"line": line,
+				}).Debug("Attempting to process json log line")
 
-		// take care of any headers on the line
-		var prefixFields map[string]string
-		if prefixRegex != nil {
-			var prefix string
-			prefix, prefixFields = prefixRegex.FindStringSubmatchMap(line)
-			line = strings.TrimPrefix(line, prefix)
-		}
+				// take care of any headers on the line
+				var prefixFields map[string]string
+				if prefixRegex != nil {
+					var prefix string
+					prefix, prefixFields = prefixRegex.FindStringSubmatchMap(line)
+					line = strings.TrimPrefix(line, prefix)
+				}
 
-		parsedLine, err := p.lineParser.ParseLine(line)
+				parsedLine, err := p.lineParser.ParseLine(line)
 
-		if err != nil {
-			// skip lines that won't parse
-			logrus.WithFields(logrus.Fields{
-				"line": line,
-			}).Debug("skipping line; failed to parse.")
-			continue
-		}
-		timestamp := p.getTimestamp(parsedLine)
+				if err != nil {
+					// skip lines that won't parse
+					logrus.WithFields(logrus.Fields{
+						"line": line,
+					}).Debug("skipping line; failed to parse.")
+					continue
+				}
+				timestamp := p.getTimestamp(parsedLine)
 
-		// merge the prefix fields and the parsed line contents
-		for k, v := range prefixFields {
-			parsedLine[k] = v
-		}
+				// merge the prefix fields and the parsed line contents
+				for k, v := range prefixFields {
+					parsedLine[k] = v
+				}
 
-		// send an event to Transmission
-		e := event.Event{
-			Timestamp: timestamp,
-			Data:      parsedLine,
-		}
-		send <- e
+				// send an event to Transmission
+				e := event.Event{
+					Timestamp: timestamp,
+					Data:      parsedLine,
+				}
+				send <- e
+			}
+
+			wg.Done()
+		}()
 	}
+	wg.Wait()
 	logrus.Debug("lines channel is closed, ending json processor")
 }
 

--- a/parsers/keyval/keyval.go
+++ b/parsers/keyval/keyval.go
@@ -15,8 +15,6 @@ import (
 	"github.com/honeycombio/honeytail/parsers"
 )
 
-const numParsers = 20
-
 var possibleTimeFieldNames = []string{
 	"time", "Time",
 	"timestamp", "Timestamp", "TimeStamp",
@@ -29,6 +27,8 @@ type Options struct {
 	Format        string `long:"format" description:"Format of the timestamp found in timefield (supports strftime and Golang time formats)"`
 	FilterRegex   string `long:"filter_regex" description:"a regular expression that will filter the input stream and only parse lines that match"`
 	InvertFilter  bool   `long:"invert_filter" description:"change the filter_regex to only process lines that do *not* match"`
+
+	NumParsers int `hidden:"true" description:"number of mongo parsers to spin up"`
 }
 
 type Parser struct {
@@ -98,7 +98,7 @@ func (j *KeyValLineParser) ParseLine(line string) (map[string]interface{}, error
 
 func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, prefixRegex *parsers.ExtRegexp) {
 	wg := sync.WaitGroup{}
-	for i := 0; i < numParsers; i++ {
+	for i := 0; i < p.conf.NumParsers; i++ {
 		wg.Add(1)
 		go func() {
 			for line := range lines {

--- a/parsers/keyval/keyval.go
+++ b/parsers/keyval/keyval.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -13,6 +14,8 @@ import (
 	"github.com/honeycombio/honeytail/event"
 	"github.com/honeycombio/honeytail/parsers"
 )
+
+const numParsers = 20
 
 var possibleTimeFieldNames = []string{
 	"time", "Time",
@@ -94,73 +97,81 @@ func (j *KeyValLineParser) ParseLine(line string) (map[string]interface{}, error
 }
 
 func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, prefixRegex *parsers.ExtRegexp) {
-	for line := range lines {
-		logrus.WithFields(logrus.Fields{
-			"line": line,
-		}).Debug("Attempting to process keyval log line")
-
-		// if matching regex is set, filter lines here
-		if p.filterRegex != nil {
-			matched := p.filterRegex.MatchString(line)
-			// if both are true or both are false, skip. else continue
-			if matched == p.conf.InvertFilter {
+	wg := sync.WaitGroup{}
+	for i := 0; i < numParsers; i++ {
+		wg.Add(1)
+		go func() {
+			for line := range lines {
 				logrus.WithFields(logrus.Fields{
-					"line":    line,
-					"matched": matched,
-				}).Debug("skipping line due to FilterMatch.")
-				continue
+					"line": line,
+				}).Debug("Attempting to process keyval log line")
+
+				// if matching regex is set, filter lines here
+				if p.filterRegex != nil {
+					matched := p.filterRegex.MatchString(line)
+					// if both are true or both are false, skip. else continue
+					if matched == p.conf.InvertFilter {
+						logrus.WithFields(logrus.Fields{
+							"line":    line,
+							"matched": matched,
+						}).Debug("skipping line due to FilterMatch.")
+						continue
+					}
+				}
+
+				// take care of any headers on the line
+				var prefixFields map[string]string
+				if prefixRegex != nil {
+					var prefix string
+					prefix, prefixFields = prefixRegex.FindStringSubmatchMap(line)
+					line = strings.TrimPrefix(line, prefix)
+				}
+
+				parsedLine, err := p.lineParser.ParseLine(line)
+				if err != nil {
+					// skip lines that won't parse
+					logrus.WithFields(logrus.Fields{
+						"line":  line,
+						"error": err,
+					}).Debug("skipping line; failed to parse.")
+					continue
+				}
+				if len(parsedLine) == 0 {
+					// skip empty lines, as determined by the parser
+					logrus.WithFields(logrus.Fields{
+						"line":  line,
+						"error": err,
+					}).Debug("skipping line; no key/val pairs found.")
+					continue
+				}
+				if allEmpty(parsedLine) {
+					// skip events for which all fields are the empty string, because that's
+					// probably broken
+					logrus.WithFields(logrus.Fields{
+						"line":  line,
+						"error": err,
+					}).Debug("skipping line; all values are the empty string.")
+					continue
+				}
+				// merge the prefix fields and the parsed line contents
+				for k, v := range prefixFields {
+					parsedLine[k] = v
+				}
+
+				// look for the timestamp in any of the prefix fields or regular content
+				timestamp := p.getTimestamp(parsedLine)
+
+				// send an event to Transmission
+				e := event.Event{
+					Timestamp: timestamp,
+					Data:      parsedLine,
+				}
+				send <- e
 			}
-		}
-
-		// take care of any headers on the line
-		var prefixFields map[string]string
-		if prefixRegex != nil {
-			var prefix string
-			prefix, prefixFields = prefixRegex.FindStringSubmatchMap(line)
-			line = strings.TrimPrefix(line, prefix)
-		}
-
-		parsedLine, err := p.lineParser.ParseLine(line)
-		if err != nil {
-			// skip lines that won't parse
-			logrus.WithFields(logrus.Fields{
-				"line":  line,
-				"error": err,
-			}).Debug("skipping line; failed to parse.")
-			continue
-		}
-		if len(parsedLine) == 0 {
-			// skip empty lines, as determined by the parser
-			logrus.WithFields(logrus.Fields{
-				"line":  line,
-				"error": err,
-			}).Debug("skipping line; no key/val pairs found.")
-			continue
-		}
-		if allEmpty(parsedLine) {
-			// skip events for which all fields are the empty string, because that's
-			// probably broken
-			logrus.WithFields(logrus.Fields{
-				"line":  line,
-				"error": err,
-			}).Debug("skipping line; all values are the empty string.")
-			continue
-		}
-		// merge the prefix fields and the parsed line contents
-		for k, v := range prefixFields {
-			parsedLine[k] = v
-		}
-
-		// look for the timestamp in any of the prefix fields or regular content
-		timestamp := p.getTimestamp(parsedLine)
-
-		// send an event to Transmission
-		e := event.Event{
-			Timestamp: timestamp,
-			Data:      parsedLine,
-		}
-		send <- e
+			wg.Done()
+		}()
 	}
+	wg.Wait()
 	logrus.Debug("lines channel is closed, ending keyval processor")
 }
 

--- a/parsers/keyval/keyval_test.go
+++ b/parsers/keyval/keyval_test.go
@@ -77,6 +77,9 @@ func TestBrokenFilterRegex(t *testing.T) {
 
 func TestFilterRegex(t *testing.T) {
 	p := &Parser{
+		conf: Options{
+			NumParsers: 5,
+		},
 		lineParser: &NoopLineParser{
 			outgoingMap: map[string]interface{}{"key": "val"},
 		},
@@ -164,6 +167,9 @@ func TestDontReturnEmptyEvents(t *testing.T) {
 	p := &Parser{
 		lineParser: &NoopLineParser{},
 		nower:      &FakeNower{},
+		conf: Options{
+			NumParsers: 5,
+		},
 	}
 	lines := make(chan string)
 	send := make(chan event.Event)

--- a/parsers/mongodb/mongodb.go
+++ b/parsers/mongodb/mongodb.go
@@ -4,6 +4,7 @@ package mongodb
 import (
 	"errors"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -13,6 +14,8 @@ import (
 	"github.com/honeycombio/honeytail/event"
 	"github.com/honeycombio/honeytail/parsers"
 )
+
+const numParsers = 20
 
 const (
 	// https://github.com/rueckstiess/mongodb-log-spec#timestamps
@@ -76,84 +79,92 @@ func (p *Parser) Init(options interface{}) error {
 }
 
 func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, prefixRegex *parsers.ExtRegexp) {
-	for line := range lines {
-		// take care of any headers on the line
-		var prefixFields map[string]string
-		if prefixRegex != nil {
-			var prefix string
-			prefix, prefixFields = prefixRegex.FindStringSubmatchMap(line)
-			line = strings.TrimPrefix(line, prefix)
-		}
-		values, err := p.lineParser.ParseLogLine(line)
-		// we get a bunch of errors from the parser on mongo logs, skip em
-		if err == nil || (p.conf.LogPartials && logparser.IsPartialLogLine(err)) {
-			timestamp, err := p.parseTimestamp(values)
-			if err != nil {
-				logFailure(line, err, "couldn't parse logline timestamp, skipping")
-				continue
-			}
-			if err = p.decomposeSharding(values); err != nil {
-				logFailure(line, err, "couldn't decompose sharding changelog, skipping")
-				continue
-			}
-			if err = p.decomposeNamespace(values); err != nil {
-				logFailure(line, err, "couldn't decompose logline namespace, skipping")
-				continue
-			}
-			if err = p.decomposeLocks(values); err != nil {
-				logFailure(line, err, "couldn't decompose logline locks, skipping")
-				continue
-			}
-			if err = p.decomposeLocksMicros(values); err != nil {
-				logFailure(line, err, "couldn't decompose logline locks(micros), skipping")
-				continue
-			}
-
-			p.getCommandQuery(values)
-
-			if q, ok := values["query"].(map[string]interface{}); ok {
-				if _, ok = values["normalized_query"]; !ok {
-					// also calculate the query_shape if we can
-					values["normalized_query"] = queryshape.GetQueryShape(q)
+	wg := sync.WaitGroup{}
+	for i := 0; i < numParsers; i++ {
+		wg.Add(1)
+		go func() {
+			for line := range lines {
+				// take care of any headers on the line
+				var prefixFields map[string]string
+				if prefixRegex != nil {
+					var prefix string
+					prefix, prefixFields = prefixRegex.FindStringSubmatchMap(line)
+					line = strings.TrimPrefix(line, prefix)
 				}
-			}
+				values, err := p.lineParser.ParseLogLine(line)
+				// we get a bunch of errors from the parser on mongo logs, skip em
+				if err == nil || (p.conf.LogPartials && logparser.IsPartialLogLine(err)) {
+					timestamp, err := p.parseTimestamp(values)
+					if err != nil {
+						logFailure(line, err, "couldn't parse logline timestamp, skipping")
+						continue
+					}
+					if err = p.decomposeSharding(values); err != nil {
+						logFailure(line, err, "couldn't decompose sharding changelog, skipping")
+						continue
+					}
+					if err = p.decomposeNamespace(values); err != nil {
+						logFailure(line, err, "couldn't decompose logline namespace, skipping")
+						continue
+					}
+					if err = p.decomposeLocks(values); err != nil {
+						logFailure(line, err, "couldn't decompose logline locks, skipping")
+						continue
+					}
+					if err = p.decomposeLocksMicros(values); err != nil {
+						logFailure(line, err, "couldn't decompose logline locks(micros), skipping")
+						continue
+					}
 
-			if ns, ok := values["namespace"].(string); ok && ns == "admin.$cmd" {
-				if cmdType, ok := values["command_type"]; ok && cmdType == "replSetHeartbeat" {
-					if cmd, ok := values["command"].(map[string]interface{}); ok {
-						if replicaSet, ok := cmd["replSetHeartbeat"].(string); ok {
-							p.currentReplicaSet = replicaSet
+					p.getCommandQuery(values)
+
+					if q, ok := values["query"].(map[string]interface{}); ok {
+						if _, ok = values["normalized_query"]; !ok {
+							// also calculate the query_shape if we can
+							values["normalized_query"] = queryshape.GetQueryShape(q)
 						}
 					}
+
+					if ns, ok := values["namespace"].(string); ok && ns == "admin.$cmd" {
+						if cmdType, ok := values["command_type"]; ok && cmdType == "replSetHeartbeat" {
+							if cmd, ok := values["command"].(map[string]interface{}); ok {
+								if replicaSet, ok := cmd["replSetHeartbeat"].(string); ok {
+									p.currentReplicaSet = replicaSet
+								}
+							}
+						}
+					}
+
+					if p.currentReplicaSet != "" {
+						values["replica_set"] = p.currentReplicaSet
+					}
+
+					// merge the prefix fields and the parsed line contents
+					for k, v := range prefixFields {
+						values[k] = v
+					}
+
+					logrus.WithFields(logrus.Fields{
+						"line":   line,
+						"values": values,
+					}).Debug("Successfully parsed line")
+
+					// we'll be putting the timestamp in the Event
+					// itself, no need to also have it in the Data
+					delete(values, timestampFieldName)
+
+					send <- event.Event{
+						Timestamp: timestamp,
+						Data:      values,
+					}
+				} else {
+					logFailure(line, err, "logline didn't parse, skipping.")
 				}
 			}
-
-			if p.currentReplicaSet != "" {
-				values["replica_set"] = p.currentReplicaSet
-			}
-
-			// merge the prefix fields and the parsed line contents
-			for k, v := range prefixFields {
-				values[k] = v
-			}
-
-			logrus.WithFields(logrus.Fields{
-				"line":   line,
-				"values": values,
-			}).Debug("Successfully parsed line")
-
-			// we'll be putting the timestamp in the Event
-			// itself, no need to also have it in the Data
-			delete(values, timestampFieldName)
-
-			send <- event.Event{
-				Timestamp: timestamp,
-				Data:      values,
-			}
-		} else {
-			logFailure(line, err, "logline didn't parse, skipping.")
-		}
+			wg.Done()
+		}()
 	}
+	wg.Wait()
 	logrus.Debug("lines channel is closed, ending mongo processor")
 }
 

--- a/parsers/mongodb/mongodb.go
+++ b/parsers/mongodb/mongodb.go
@@ -15,8 +15,6 @@ import (
 	"github.com/honeycombio/honeytail/parsers"
 )
 
-const numParsers = 20
-
 const (
 	// https://github.com/rueckstiess/mongodb-log-spec#timestamps
 	ctimeNoMSTimeFormat    = "Mon Jan _2 15:04:05"

--- a/parsers/mongodb/mongodb_test.go
+++ b/parsers/mongodb/mongodb_test.go
@@ -410,9 +410,14 @@ func TestProcessLines(t *testing.T) {
 		},
 	}
 	m := &Parser{
-		conf:       Options{},
-		nower:      nower,
-		lineParser: &MongoLineParser{},
+		conf: Options{
+			NumParsers: 5,
+		},
+		nower: nower,
+	}
+	m.lineParsers = make([]LineParser, m.conf.NumParsers)
+	for i := 0; i < m.conf.NumParsers; i++ {
+		m.lineParsers[i] = &MongoLineParser{}
 	}
 	lines := make(chan string)
 	send := make(chan event.Event)

--- a/parsers/mongodb/mongodb_test.go
+++ b/parsers/mongodb/mongodb_test.go
@@ -425,32 +425,36 @@ func TestProcessLines(t *testing.T) {
 	}()
 	// spin up the processor to process our test lines
 	go m.ProcessLines(lines, send, nil)
-	for _, pair := range tlm {
+	for range tlm {
 		ev := <-send
-
-		if ev.Timestamp.UnixNano() != pair.expected.time.UnixNano() {
-			t.Errorf("Parsed timestamp didn't match up for %s.\n  Expected: %+v\n  Actual: %+v",
-				pair.line, pair.expected.time, ev.Timestamp)
-		}
-
-		var missing []string
-		for k := range pair.expected.includeData {
-			if _, ok := ev.Data[k]; !ok {
-				missing = append(missing, k)
-			} else if !reflect.DeepEqual(ev.Data[k], pair.expected.includeData[k]) {
-				t.Errorf("  Parsed data value %s didn't match up for %s.\n  Expected: %+v\n  Actual: %+v",
-					k, pair.line, pair.expected.includeData[k], ev.Data[k])
+		var found bool
+		for _, pair := range tlm {
+			if ev.Timestamp.UnixNano() != pair.expected.time.UnixNano() {
+				continue
 			}
-		}
-		if missing != nil {
-			t.Errorf("  Parsed data was missing keys for line: %s\n  Missing: %+v\n  Parsed data: %+v",
-				pair.line, missing, ev.Data)
-		}
-		for _, k := range pair.expected.excludeKeys {
-			if _, ok := ev.Data[k]; ok {
-				t.Errorf("  Parsed data included unexpected key %s for line: %s", k, pair.line)
+
+			var missing []string
+			for k := range pair.expected.includeData {
+				if _, ok := ev.Data[k]; !ok {
+					missing = append(missing, k)
+				} else if !reflect.DeepEqual(ev.Data[k], pair.expected.includeData[k]) {
+					continue
+				}
 			}
+			if missing != nil {
+				continue
+			}
+			for _, k := range pair.expected.excludeKeys {
+				if _, ok := ev.Data[k]; ok {
+					continue
+				}
+			}
+			found = true
 		}
+		if !found {
+			t.Errorf("couldn't find event %+v", ev)
+		}
+		found = false
 	}
 }
 

--- a/parsers/mysql/mysql.go
+++ b/parsers/mysql/mysql.go
@@ -144,6 +144,10 @@ type Parser struct {
 	readOnly   *bool
 	replicaLag *int64
 	role       *string
+}
+
+// the normalizer can't be shared by all threads.
+type perThreadParser struct {
 	normalizer *normalizer.Parser
 }
 
@@ -160,7 +164,6 @@ func (n *RealNower) Now() time.Time {
 func (p *Parser) Init(options interface{}) error {
 	p.conf = *options.(*Options)
 	p.nower = &RealNower{}
-	p.normalizer = &normalizer.Parser{}
 	if p.conf.Host != "" {
 		url := fmt.Sprintf("%s:%s@tcp(%s)/", p.conf.User, p.conf.Pass, p.conf.Host)
 		db, err := sql.Open("mysql", url)
@@ -362,10 +365,13 @@ func (p *Parser) handleEvents(rawEvents <-chan []string, send chan<- event.Event
 	defer p.wg.Done()
 	wg := sync.WaitGroup{}
 	for i := 0; i < numParsers; i++ {
+		ptp := perThreadParser{
+			normalizer: &normalizer.Parser{},
+		}
 		wg.Add(1)
 		go func() {
 			for rawE := range rawEvents {
-				sq, timestamp := p.handleEvent(rawE)
+				sq, timestamp := p.handleEvent(&ptp, rawE)
 				if len(sq) == 0 {
 					continue
 				}
@@ -400,7 +406,8 @@ func (p *Parser) handleEvents(rawEvents <-chan []string, send chan<- event.Event
 // Parse a set of MySQL log lines that seem to represent a single event and
 // return a struct of extracted data as well as the highest-resolution timestamp
 // available.
-func (p *Parser) handleEvent(rawE []string) (map[string]interface{}, time.Time) {
+func (p *Parser) handleEvent(ptp *perThreadParser, rawE []string) (
+	map[string]interface{}, time.Time) {
 	sq := map[string]interface{}{}
 	var timeFromComment time.Time
 	var timeFromSet int64
@@ -506,14 +513,14 @@ func (p *Parser) handleEvent(rawE []string) (map[string]interface{}, time.Time) 
 			if strings.HasSuffix(query, ";") {
 				q := strings.TrimSpace(strings.TrimSuffix(query, ";"))
 				sq[queryKey] = q
-				sq[normalizedQueryKey] = p.normalizer.NormalizeQuery(q)
-				if len(p.normalizer.LastTables) > 0 {
-					sq[tablesKey] = strings.Join(p.normalizer.LastTables, " ")
+				sq[normalizedQueryKey] = ptp.normalizer.NormalizeQuery(q)
+				if len(ptp.normalizer.LastTables) > 0 {
+					sq[tablesKey] = strings.Join(ptp.normalizer.LastTables, " ")
 				}
-				if len(p.normalizer.LastComments) > 0 {
-					sq[commentsKey] = "/* " + strings.Join(p.normalizer.LastComments, " */ /* ") + " */"
+				if len(ptp.normalizer.LastComments) > 0 {
+					sq[commentsKey] = "/* " + strings.Join(ptp.normalizer.LastComments, " */ /* ") + " */"
 				}
-				sq[statementKey] = p.normalizer.LastStatement
+				sq[statementKey] = ptp.normalizer.LastStatement
 				query = ""
 			}
 		} else {

--- a/parsers/mysql/mysql.go
+++ b/parsers/mysql/mysql.go
@@ -50,8 +50,6 @@ import (
 // SET timestamp=1476127288;
 // SELECT * FROM foo WHERE bar=2 AND (baz=104 OR baz=0) ORDER BY baz;
 
-const numParsers = 20
-
 const (
 	rdsStr  = "rds"
 	ec2Str  = "ec2"
@@ -130,6 +128,8 @@ type Options struct {
 	User          string `long:"user" description:"MySQL username"`
 	Pass          string `long:"pass" description:"MySQL password"`
 	QueryInterval uint   `long:"interval" description:"interval for querying the MySQL DB in seconds" default:"30"`
+
+	NumParsers int `hidden:"true" description:"number of mongo parsers to spin up"`
 }
 
 type Parser struct {
@@ -364,7 +364,7 @@ func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, pref
 func (p *Parser) handleEvents(rawEvents <-chan []string, send chan<- event.Event) {
 	defer p.wg.Done()
 	wg := sync.WaitGroup{}
-	for i := 0; i < numParsers; i++ {
+	for i := 0; i < p.conf.NumParsers; i++ {
 		ptp := perThreadParser{
 			normalizer: &normalizer.Parser{},
 		}

--- a/parsers/mysql/mysql_test.go
+++ b/parsers/mysql/mysql_test.go
@@ -719,6 +719,9 @@ func TestProcessLines(t *testing.T) {
 
 	for _, tt := range tsts {
 		p := &Parser{
+			conf: Options{
+				NumParsers: 5,
+			},
 			nower: &FakeNower{},
 			// normalizer: &normalizer.Parser{},
 		}
@@ -756,6 +759,9 @@ func TestProcessLines(t *testing.T) {
 	var numEvents int
 	for _, tt := range tsts {
 		p := &Parser{
+			conf: Options{
+				NumParsers: 5,
+			},
 			SampleRate: 3,
 			nower:      &FakeNower{},
 			// normalizer: &normalizer.Parser{},

--- a/parsers/mysql/mysql_test.go
+++ b/parsers/mysql/mysql_test.go
@@ -466,11 +466,13 @@ var sqds = []slowQueryData{
 
 func TestHandleEvent(t *testing.T) {
 	p := &Parser{
-		nower:      &FakeNower{},
+		nower: &FakeNower{},
+	}
+	ptp := &perThreadParser{
 		normalizer: &normalizer.Parser{},
 	}
 	for i, sqd := range sqds {
-		res, timestamp := p.handleEvent(sqd.rawE)
+		res, timestamp := p.handleEvent(ptp, sqd.rawE)
 		if len(res) != len(sqd.sq) {
 			t.Errorf("case num %d: expected to parse %d fields, got %d", i, len(sqd.sq), len(res))
 			fmt.Printf("res is %+v\n", res)
@@ -491,6 +493,9 @@ func TestTimeProcessing(t *testing.T) {
 	p := &Parser{
 		nower: &FakeNower{},
 	}
+	ptp := &perThreadParser{
+		normalizer: &normalizer.Parser{},
+	}
 	tsts := []struct {
 		lines    []string
 		expected time.Time
@@ -510,7 +515,7 @@ func TestTimeProcessing(t *testing.T) {
 	}
 
 	for _, tt := range tsts {
-		_, timestamp := p.handleEvent(tt.lines)
+		_, timestamp := p.handleEvent(ptp, tt.lines)
 		if timestamp.Unix() != tt.expected.Unix() {
 			t.Errorf("Didn't capture unix ts from lines:\n%+v\n\tExpected: %d, Actual: %d",
 				strings.Join(tt.lines, "\n"), tt.expected.Unix(), timestamp.Unix())
@@ -714,8 +719,8 @@ func TestProcessLines(t *testing.T) {
 
 	for _, tt := range tsts {
 		p := &Parser{
-			nower:      &FakeNower{},
-			normalizer: &normalizer.Parser{},
+			nower: &FakeNower{},
+			// normalizer: &normalizer.Parser{},
 		}
 		lines := make(chan string, 10)
 		send := make(chan event.Event, 5)
@@ -728,13 +733,18 @@ func TestProcessLines(t *testing.T) {
 		}
 		close(lines)
 
-		for _, exp := range tt.expected {
+		for range tt.expected {
 			ev := <-send
-			if !ev.Timestamp.Equal(exp.Timestamp) {
-				t.Errorf("time parsing mismatch. got %+v, expected %+v", ev.Timestamp, exp.Timestamp)
+			var found bool
+			// returned events may come out of order so just look for the event rather
+			// than expecting it to come in order
+			for _, exp := range tt.expected {
+				if ev.Timestamp.Equal(exp.Timestamp) && reflect.DeepEqual(ev.Data, exp.Data) {
+					found = true
+				}
 			}
-			if !reflect.DeepEqual(ev.Data, exp.Data) {
-				t.Errorf("data parsing mismatch. got %+v, expected %+v", ev.Data, exp.Data)
+			if !found {
+				t.Errorf("ev\n%+v\nnot found in expected list:\n%+v\n", ev, tt.expected)
 			}
 		}
 		if len(send) > 0 {
@@ -748,7 +758,7 @@ func TestProcessLines(t *testing.T) {
 		p := &Parser{
 			SampleRate: 3,
 			nower:      &FakeNower{},
-			normalizer: &normalizer.Parser{},
+			// normalizer: &normalizer.Parser{},
 		}
 		lines := make(chan string, 10)
 		send := make(chan event.Event, 5)

--- a/parsers/nginx/nginx.go
+++ b/parsers/nginx/nginx.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -16,6 +17,7 @@ import (
 )
 
 const (
+	numParsers                = 20
 	commonLogFormatTimeLayout = "02/Jan/2006:15:04:05 -0700"
 	iso8601TimeLayout         = "2006-01-02T15:04:05-07:00"
 )
@@ -75,44 +77,52 @@ func (g *GonxLineParser) ParseLine(line string) (map[string]string, error) {
 
 func (n *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, prefixRegex *parsers.ExtRegexp) {
 	// parse lines one by one
-	for line := range lines {
-		logrus.WithFields(logrus.Fields{
-			"line": line,
-		}).Debug("Attempting to process nginx log line")
+	wg := sync.WaitGroup{}
+	for i := 0; i < numParsers; i++ {
+		wg.Add(1)
+		go func() {
+			for line := range lines {
+				logrus.WithFields(logrus.Fields{
+					"line": line,
+				}).Debug("Attempting to process nginx log line")
 
-		// take care of any headers on the line
-		var prefixFields map[string]string
-		if prefixRegex != nil {
-			var prefix string
-			prefix, prefixFields = prefixRegex.FindStringSubmatchMap(line)
-			line = strings.TrimPrefix(line, prefix)
-		}
+				// take care of any headers on the line
+				var prefixFields map[string]string
+				if prefixRegex != nil {
+					var prefix string
+					prefix, prefixFields = prefixRegex.FindStringSubmatchMap(line)
+					line = strings.TrimPrefix(line, prefix)
+				}
 
-		parsedLine, err := n.lineParser.ParseLine(line)
-		if err != nil {
-			continue
-		}
-		// merge the prefix fields and the parsed line contents
-		for k, v := range prefixFields {
-			parsedLine[k] = v
-		}
-		// typedEvent, err := typeifyEvent(nginxEvent)
-		typedEvent, err := typeifyParsedLine(parsedLine)
-		if err != nil {
-			logrus.WithFields(logrus.Fields{
-				"line":  line,
-				"event": parsedLine,
-			}).Debug("failed to typeify event")
-			continue
-		}
-		timestamp := getTimestamp(n.nower, typedEvent)
+				parsedLine, err := n.lineParser.ParseLine(line)
+				if err != nil {
+					continue
+				}
+				// merge the prefix fields and the parsed line contents
+				for k, v := range prefixFields {
+					parsedLine[k] = v
+				}
+				// typedEvent, err := typeifyEvent(nginxEvent)
+				typedEvent, err := typeifyParsedLine(parsedLine)
+				if err != nil {
+					logrus.WithFields(logrus.Fields{
+						"line":  line,
+						"event": parsedLine,
+					}).Debug("failed to typeify event")
+					continue
+				}
+				timestamp := getTimestamp(n.nower, typedEvent)
 
-		e := event.Event{
-			Timestamp: timestamp,
-			Data:      typedEvent,
-		}
-		send <- e
+				e := event.Event{
+					Timestamp: timestamp,
+					Data:      typedEvent,
+				}
+				send <- e
+			}
+			wg.Done()
+		}()
 	}
+	wg.Wait()
 	logrus.Debug("lines channel is closed, ending nginx processor")
 }
 

--- a/parsers/nginx/nginx.go
+++ b/parsers/nginx/nginx.go
@@ -17,7 +17,6 @@ import (
 )
 
 const (
-	numParsers                = 20
 	commonLogFormatTimeLayout = "02/Jan/2006:15:04:05 -0700"
 	iso8601TimeLayout         = "2006-01-02T15:04:05-07:00"
 )
@@ -25,6 +24,8 @@ const (
 type Options struct {
 	ConfigFile    flag.Filename `long:"conf" description:"Path to Nginx config file"`
 	LogFormatName string        `long:"format" description:"Log format name to look for in the Nginx config file"`
+
+	NumParsers int `hidden:"true" description:"number of mongo parsers to spin up"`
 }
 
 type Parser struct {
@@ -78,7 +79,7 @@ func (g *GonxLineParser) ParseLine(line string) (map[string]string, error) {
 func (n *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, prefixRegex *parsers.ExtRegexp) {
 	// parse lines one by one
 	wg := sync.WaitGroup{}
-	for i := 0; i < numParsers; i++ {
+	for i := 0; i < n.conf.NumParsers; i++ {
 		wg.Add(1)
 		go func() {
 			for line := range lines {

--- a/parsers/nginx/nginx_test.go
+++ b/parsers/nginx/nginx_test.go
@@ -72,7 +72,9 @@ func TestProcessLines(t *testing.T) {
 		},
 	}
 	p := &Parser{
-		conf: Options{},
+		conf: Options{
+			NumParsers: 5,
+		},
 		lineParser: &FakeLineParser{
 			tlm: tlm,
 		},
@@ -131,7 +133,9 @@ func TestProcessLinesNoPreReg(t *testing.T) {
 		},
 	}
 	p := &Parser{
-		conf: Options{},
+		conf: Options{
+			NumParsers: 5,
+		},
 		lineParser: &FakeLineParser{
 			tlm: tlm,
 		},


### PR DESCRIPTION
Once the tailer reads a line, it hands it off to the parser. The parser sends it through a whole chain of channels to get adjusted before it gets to libhoney.
The disk is not the bottleneck, and libhoney is getting batching, removing it as the bottleneck. That leaves the parser and all the munging parts.
This change configures all the munging channels to use as many goroutines as the senders, so that CPU intensive things like calculating SHA hashes or parsing URLs into constituent parts can be done in parallel, if you have the CPUs for it.
Additionally, it sets each of the parsers to run 20 goroutines, in hopes that they will be able to more efficiently drain the channel coming from the tailer. The parsers all treat each line as an independent event, so there is no danger (except maybe mixing up the final order a bit, which is fine) in increasing the number of workers doing the heavy lifting of the parser.