### PR TITLE
update json parser to pass through nested objects

### DIFF
--- a/parsers/htjson/htjson.go
+++ b/parsers/htjson/htjson.go
@@ -62,28 +62,13 @@ type LineParser interface {
 type JSONLineParser struct {
 }
 
-// LineParser will do a complete JSON decode of the line,
-// but then re-encode any value that's not a string as JSON and return
-// it as a string. We don't want nested objects, but it seems silly to
-// balk instead of just pushing json as the value into retriever.
+// ParseLine will unmarshal the thing it read in to detect errors in the JSON
+// (by failing to parse) and give us an object that can be mutated by the
+// various filters honeytail might apply.
 func (j *JSONLineParser) ParseLine(line string) (map[string]interface{}, error) {
 	parsed := make(map[string]interface{})
 	err := json.Unmarshal([]byte(line), &parsed)
-	if err != nil {
-		return nil, err
-	}
-	processed := make(map[string]interface{})
-	for k, v := range parsed {
-		switch typedVal := v.(type) {
-		case bool, string, float64:
-			processed[k] = typedVal
-		default:
-			rejsoned, _ := json.Marshal(v)
-			processed[k] = string(rejsoned)
-
-		}
-	}
-	return processed, err
+	return parsed, err
 }
 
 func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, prefixRegex *parsers.ExtRegexp) {

--- a/parsers/htjson/htjson_test.go
+++ b/parsers/htjson/htjson_test.go
@@ -36,9 +36,10 @@ var tlms = []testLineMap{
 		},
 	},
 	{ // non-flat json object
-		input: `{"array": [3, 4, 6], "myfloat": 4.234}`,
+		input: `{"array": [3, 4, 6], "obj": {"subkey":"subval"}, "myfloat": 4.234}`,
 		expected: map[string]interface{}{
-			"array":   "[3,4,6]",
+			"array":   []interface{}{float64(3), float64(4), float64(6)},
+			"obj":     map[string]interface{}{"subkey": "subval"},
 			"myfloat": 4.234,
 		},
 	},


### PR DESCRIPTION
Honeycomb used to drop incoming events that had nested JSON. It no longer does, so this change passes through JSON objects that have any kind of nesting instead of stringifying the nested structure.
Fixes issue #53