### PR TITLE
Use common LineParser interface in individual parsers.

### DIFF
--- a/parsers/arangodb/arangodb.go
+++ b/parsers/arangodb/arangodb.go
@@ -47,12 +47,7 @@ type Options struct {
 // Parser for log lines.
 type Parser struct {
 	conf       Options
-	lineParser LineParser
-}
-
-// LineParser interface to parse a line of a log file.
-type LineParser interface {
-	ParseLogLine(line string) (map[string]interface{}, error)
+	lineParser parsers.LineParser
 }
 
 // ArangoLineParser is a LineParser for ArangoDB log files.
@@ -100,8 +95,8 @@ func removeQuotes(word string) string {
 	return word
 }
 
-// ParseLogLine method for an ArangoLineParser implementing LineParser.
-func (m *ArangoLineParser) ParseLogLine(line string) (_ map[string]interface{}, err error) {
+// ParseLine method for an ArangoLineParser implementing LineParser.
+func (m *ArangoLineParser) ParseLine(line string) (_ map[string]interface{}, err error) {
 	// Do the actual work here, we look for log lines in the log topic "requests",
 	// there are two types, one is a DEBUG line (could be switched off) containing
 	// the request body, the other is the INFO line marking the end of the
@@ -187,7 +182,7 @@ func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, pref
 					line = strings.TrimPrefix(line, prefix)
 				}
 
-				values, err := p.lineParser.ParseLogLine(line)
+				values, err := p.lineParser.ParseLine(line)
 				// we get a bunch of errors from the parser on ArangoDB logs, skip em
 				if err == nil {
 					timestamp, err := p.parseTimestamp(values)

--- a/parsers/htjson/htjson.go
+++ b/parsers/htjson/htjson.go
@@ -23,7 +23,7 @@ type Options struct {
 
 type Parser struct {
 	conf       Options
-	lineParser LineParser
+	lineParser parsers.LineParser
 
 	warnedAboutTime bool
 }
@@ -33,10 +33,6 @@ func (p *Parser) Init(options interface{}) error {
 
 	p.lineParser = &JSONLineParser{}
 	return nil
-}
-
-type LineParser interface {
-	ParseLine(line string) (map[string]interface{}, error)
 }
 
 type JSONLineParser struct {

--- a/parsers/keyval/keyval.go
+++ b/parsers/keyval/keyval.go
@@ -26,7 +26,7 @@ type Options struct {
 
 type Parser struct {
 	conf        Options
-	lineParser  LineParser
+	lineParser  parsers.LineParser
 	filterRegex *regexp.Regexp
 
 	warnedAboutTime bool
@@ -43,11 +43,6 @@ func (p *Parser) Init(options interface{}) error {
 
 	p.lineParser = &KeyValLineParser{}
 	return nil
-}
-
-// TODO dedupe the LineParser interface with the json parser or remove entirely
-type LineParser interface {
-	ParseLine(line string) (map[string]interface{}, error)
 }
 
 type KeyValLineParser struct {

--- a/parsers/mongodb/mongodb_test.go
+++ b/parsers/mongodb/mongodb_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/honeycombio/honeytail/event"
 	"github.com/honeycombio/honeytail/httime"
 	"github.com/honeycombio/honeytail/httime/httimetest"
+	"github.com/honeycombio/honeytail/parsers"
 )
 
 const (
@@ -420,7 +421,7 @@ func TestProcessLines(t *testing.T) {
 			NumParsers: 5,
 		},
 	}
-	m.lineParsers = make([]LineParser, m.conf.NumParsers)
+	m.lineParsers = make([]parsers.LineParser, m.conf.NumParsers)
 	for i := 0; i < m.conf.NumParsers; i++ {
 		m.lineParsers[i] = &MongoLineParser{}
 	}

--- a/parsers/parsers.go
+++ b/parsers/parsers.go
@@ -14,3 +14,7 @@ type Parser interface {
 	// line prior to parsing. Any named groups will be added to the event.
 	ProcessLines(lines <-chan string, send chan<- event.Event, prefixRegex *ExtRegexp)
 }
+
+type LineParser interface {
+	ParseLine(line string) (map[string]interface{}, error)
+}


### PR DESCRIPTION
Previously, each parser package defined a more-or-less duplicated `LineParser`
interface. Unify them to all implement the same interface.

This doesn't change honeytail behavior, but makes it easier to reuse individual
parsers in the fledgling kubernetes agent.

Test plan: Unit tests