### PR TITLE
Change default below which dynsampling is disabled, allow override

### DIFF
--- a/leash.go
+++ b/leash.go
@@ -263,6 +263,7 @@ func modifyEventContents(toBeSent chan event.Event, options GlobalOptions) chan 
 		sampler = &dynsampler.AvgSampleWithMin{
 			GoalSampleRate:    options.GoalSampleRate,
 			ClearFrequencySec: options.DynWindowSec,
+			MinEventsPerSec:   options.MinSampleRate,
 		}
 		if err := sampler.Start(); err != nil {
 			logrus.WithField("error", err).Fatal("dynsampler failed to start")

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ type GlobalOptions struct {
 	DynSample         []string `long:"dynsampling" description:"enable dynamic sampling using the field listed in this option. May be specified multiple times; fields will be concatenated to form the dynsample key. WARNING increases CPU utilization dramatically over normal sampling"`
 	DynWindowSec      int      `long:"dynsample_window" description:"measurement window size for the dynsampler, in seconds" default:"30"`
 	GoalSampleRate    int      `hidden:"true" description:"used to hold the desired sample rate and set tailing sample rate to 1"`
+	MinSampleRate     int      `long:"dynsample_minimum" description:"if the rate of traffic falls below this, dynsampler won't sample" default:"1"`
 
 	Reqs  RequiredOptions `group:"Required Options"`
 	Modes OtherModes      `group:"Other Modes"`


### PR DESCRIPTION
The dynamic sampling algorithm used in honeytail is [Average with Minimum](https://godoc.org/github.com/honeycombio/dynsampler-go#AvgSampleWithMin). The default minimum throughput under which sampling is disabled is 50. This is too high a default for honeytail, where (in a scaled out system) each host may be handling only tens of requests per second. 

This change adjusts the default to 1 because it's kind of weird to enable dynsampling but not see it take effect. For the folks that dig in to their system and really want to have a high minimum threshold, it adds a flag to set the minimum.