### PR TITLE
Add function to convert to HT's flag.Filename

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -1,0 +1,7 @@
+package types
+
+import flags "github.com/jessevdk/go-flags"
+
+func FilenameFlagFromString(str string) flags.Filename {
+	return flags.Filename(str)
+}


### PR DESCRIPTION
cc @maplebed @emfree 

It might seem weird, but it's needed to use `nginx.Parser` in https://github.com/honeycombio/honeyelb. If you try to do a type conversion to `flag.Filename` in `honeyelb` and pass it to `honeytail` it won't compile because these two modules are different:

- `github.com/honeycombio/honeytail/vendor/github.com/jessevdk/go-flags`
- `github.com/honeycombio/honeyelb/vendor/github.com/jessevdk/go-flags`

 are different import paths (and therefore different types as far as Go is concerned). And you can't import `vendor/` packages from another code repo directly, it's not allowed.

Open to ideas but this seems the fastest route.

Signed-off-by: Nathan LeClaire <nathan@honeycomb.io>