### PR TITLE
Don't use regex to match MySQL queries

### DIFF
--- a/parsers/mysql/mysql_test.go
+++ b/parsers/mysql/mysql_test.go
@@ -483,7 +483,7 @@ func init() {
 			},
 			timestamp: time.Unix(1476901800, 0),
 		},
-		{ /* 25 */
+		{ /* 24 */
 			rawE: []string{
 				"# User@Host: rdsadmin[rdsadmin] @ localhost [127.0.0.1]  Id:     1",
 				"# Query_time: 0.000439  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 0",
@@ -504,7 +504,7 @@ func init() {
 			},
 			timestamp: time.Unix(1476901800, 0),
 		},
-		{ /* 24 */
+		{ /* 25 */
 			rawE: []string{
 				"# User@Host: rdsadmin[rdsadmin] @ localhost [127.0.0.1]  Id:     1",
 				"# Query_time: 0.000439  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 0",

--- a/parsers/mysql/mysql_test.go
+++ b/parsers/mysql/mysql_test.go
@@ -483,6 +483,47 @@ func init() {
 			},
 			timestamp: time.Unix(1476901800, 0),
 		},
+		{ /* 25 */
+			rawE: []string{
+				"# User@Host: rdsadmin[rdsadmin] @ localhost [127.0.0.1]  Id:     1",
+				"# Query_time: 0.000439  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 0",
+				"SET timestamp=1476901800;",
+				"SELECT * FROM users WHERE id='#';",
+			},
+			sq: map[string]interface{}{
+				userKey:            "rdsadmin",
+				clientKey:          "localhost [127.0.0.1]",
+				queryTimeKey:       0.000439,
+				lockTimeKey:        0.0,
+				rowsSentKey:        1,
+				rowsExaminedKey:    0,
+				queryKey:           "SELECT * FROM users WHERE id='#'",
+				normalizedQueryKey: "select * from users where id = ?",
+				statementKey:       "select",
+				tablesKey:          "users",
+			},
+			timestamp: time.Unix(1476901800, 0),
+		},
+		{ /* 24 */
+			rawE: []string{
+				"# User@Host: rdsadmin[rdsadmin] @ localhost [127.0.0.1]  Id:     1",
+				"# Query_time: 0.000439  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 0",
+				"SET timestamp=1476901800;",
+				"SELECT 1 /* this is a comment with a # in it */;",
+			},
+			sq: map[string]interface{}{
+				userKey:            "rdsadmin",
+				clientKey:          "localhost [127.0.0.1]",
+				queryTimeKey:       0.000439,
+				lockTimeKey:        0.0,
+				rowsSentKey:        1,
+				rowsExaminedKey:    0,
+				queryKey:           "SELECT 1 /* this is a comment with a # in it */",
+				normalizedQueryKey: "select ?",
+				statementKey:       "select",
+			},
+			timestamp: time.Unix(1476901800, 0),
+		},
 	}
 }
 


### PR DESCRIPTION
Previously, when parsing a MySQL query string, the MySQL parser would match a
line up to the first '#' character with the `reQuery` regular expression.

The intent must be to strip comments; however, this strategy fails when parsing
valid queries such as
```
SELECT * FROM images WHERE hashtag="#ballin";
```

or when parsing query strings that include a '#' character in a C-style comment
block:
```
SELECT 1 /* callsite:class#method */;
```
etc.

Instead, treat the whole line as part of the query string. It is true that this
doesn't properly handle query strings of the form
```
SELECT * FROM users # comment here
    WHERE id=1;
```
However, only query strings from tcpdump or similar retain comments (the actual
slow query log strips them), so that seems like a reasonable omission.