### PR TITLE
 Add Postgres slow query parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Our complete list of parsers can be found in the [`parsers/` directory](parsers/
 - [ArangoDB](parsers/arangodb/)
 - [MongoDB](parsers/mongodb/)
 - [MySQL](parsers/mysql/)
+- [PostgreSQL](parsers/postgresql/)
 - [nginx](parsers/nginx/)
 
 ## Installation

--- a/leash.go
+++ b/leash.go
@@ -27,6 +27,7 @@ import (
 	"github.com/honeycombio/honeytail/parsers/mongodb"
 	"github.com/honeycombio/honeytail/parsers/mysql"
 	"github.com/honeycombio/honeytail/parsers/nginx"
+	"github.com/honeycombio/honeytail/parsers/postgresql"
 	"github.com/honeycombio/honeytail/tail"
 )
 
@@ -217,6 +218,8 @@ func getParserAndOptions(options GlobalOptions) (parsers.Parser, interface{}) {
 		}
 		opts = &options.MySQL
 		opts.(*mysql.Options).NumParsers = int(options.NumSenders)
+	case "postgresql":
+		parser = &postgresql.Parser{}
 	case "arangodb":
 		parser = &arangodb.Parser{}
 		opts = &options.ArangoDB

--- a/leash.go
+++ b/leash.go
@@ -219,6 +219,7 @@ func getParserAndOptions(options GlobalOptions) (parsers.Parser, interface{}) {
 		opts = &options.MySQL
 		opts.(*mysql.Options).NumParsers = int(options.NumSenders)
 	case "postgresql":
+		opts = &options.PostgreSQL
 		parser = &postgresql.Parser{}
 	case "arangodb":
 		parser = &arangodb.Parser{}

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/honeycombio/honeytail/parsers/mongodb"
 	"github.com/honeycombio/honeytail/parsers/mysql"
 	"github.com/honeycombio/honeytail/parsers/nginx"
+	"github.com/honeycombio/honeytail/parsers/postgresql"
 	"github.com/honeycombio/honeytail/tail"
 )
 
@@ -78,12 +79,13 @@ type GlobalOptions struct {
 
 	Tail tail.TailOptions `group:"Tail Options" namespace:"tail"`
 
-	ArangoDB arangodb.Options `group:"ArangoDB Parser Options" namespace:"arangodb"`
-	JSON     htjson.Options   `group:"JSON Parser Options" namespace:"json"`
-	KeyVal   keyval.Options   `group:"KeyVal Parser Options" namespace:"keyval"`
-	Mongo    mongodb.Options  `group:"MongoDB Parser Options" namespace:"mongo"`
-	MySQL    mysql.Options    `group:"MySQL Parser Options" namespace:"mysql"`
-	Nginx    nginx.Options    `group:"Nginx Parser Options" namespace:"nginx"`
+	ArangoDB   arangodb.Options   `group:"ArangoDB Parser Options" namespace:"arangodb"`
+	JSON       htjson.Options     `group:"JSON Parser Options" namespace:"json"`
+	KeyVal     keyval.Options     `group:"KeyVal Parser Options" namespace:"keyval"`
+	Mongo      mongodb.Options    `group:"MongoDB Parser Options" namespace:"mongo"`
+	MySQL      mysql.Options      `group:"MySQL Parser Options" namespace:"mysql"`
+	Nginx      nginx.Options      `group:"Nginx Parser Options" namespace:"nginx"`
+	PostgreSQL postgresql.Options `group:"PostgreSQL Parser Options" namespace:"postgresql"`
 }
 
 type RequiredOptions struct {

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ var validParsers = []string{
 	"mongo",
 	"mysql",
 	"nginx",
+	"postgresql",
 }
 
 // GlobalOptions has all the top level CLI flags that honeytail supports

--- a/parsers/postgresql/postgresql.go
+++ b/parsers/postgresql/postgresql.go
@@ -1,0 +1,122 @@
+package postgresql
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/honeycombio/honeytail/event"
+	"github.com/honeycombio/honeytail/parsers"
+	"github.com/honeycombio/mysqltools/query/normalizer"
+)
+
+var (
+	timestamp = `^(?P<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC)`
+	connIDs   = `\s+\[(?P<pid>\d+)-(?P<session_id>\d+)\]`
+	connInfo  = `\s+(?P<user>\S+)@(?P<database>\S+)`
+	level     = `\s+(?P<level>[A-Z0-9]+):`
+	duration  = `\s+duration: (?P<duration>[0-9\.]+) ms`
+	statement = `\s+statement: `
+
+	reLinePrefix = parsers.ExtRegexp{regexp.MustCompile(
+		strings.Join([]string{timestamp, connIDs, connInfo, level, duration, statement}, ""),
+	)}
+)
+
+type Parser struct{}
+
+func (p *Parser) Init(options interface{}) error {
+	return nil
+}
+
+func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, prefixRegex *parsers.ExtRegexp) {
+	rawEvents := make(chan []string)
+	go p.handleEvents(rawEvents, send)
+	var groupedLines []string
+	for line := range lines {
+		if prefixRegex != nil {
+			var prefix string
+			prefix = prefixRegex.FindString(line)
+			line = strings.TrimPrefix(line, prefix)
+		}
+		if !isContinuationLine(line) && len(groupedLines) > 0 {
+			rawEvents <- groupedLines
+			groupedLines = make([]string, 0, 1)
+		}
+		groupedLines = append(groupedLines, line)
+	}
+
+	rawEvents <- groupedLines
+	close(rawEvents)
+}
+
+func (p *Parser) handleEvents(rawEvents <-chan []string, send chan<- event.Event) {
+	// TODO: spin up a group of goroutines to do this
+	for rawEvent := range rawEvents {
+		ev := p.handleEvent(rawEvent)
+		if ev != nil {
+			send <- *ev
+		}
+	}
+}
+
+func (p *Parser) handleEvent(rawEvent []string) *event.Event {
+	normalizer := normalizer.Parser{}
+	if len(rawEvent) == 0 {
+		return nil
+	}
+	firstLine := rawEvent[0]
+
+	prefix, meta := reLinePrefix.FindStringSubmatchMap(firstLine)
+	if prefix == "" {
+		// Note: this may be noisy when debug logging is turned on, since the
+		// postgres general log contains lots of other statements as well.
+		logrus.WithField("line", firstLine).Debug("Log line didn't match expected format")
+		return nil
+	}
+
+	data := make(map[string]interface{}, len(meta))
+
+	sessionId, _ := strconv.Atoi(meta["session_id"])
+	pid, _ := strconv.Atoi(meta["pid"])
+	duration, _ := strconv.ParseFloat(meta["duration"], 64)
+
+	data["pid"] = pid
+	data["session_id"] = sessionId
+	data["duration"] = duration
+	data["user"] = meta["user"]
+	data["database"] = meta["database"]
+
+	query := firstLine[len(prefix):]
+	for _, line := range rawEvent[1:] {
+		query += " " + strings.TrimLeft(line, " \t")
+	}
+	normalizedQuery := normalizer.NormalizeQuery(query)
+
+	data["query"] = query
+	data["normalized_query"] = normalizedQuery
+	if len(normalizer.LastTables) > 0 {
+		data["tables"] = strings.Join(normalizer.LastTables, " ")
+	}
+	if len(normalizer.LastComments) > 0 {
+		data["comments"] = "/* " + strings.Join(normalizer.LastComments, " */ /* ") + " */"
+	}
+
+	timestamp, err := time.Parse("2006-01-02 03:04:05 MST", meta["time"])
+	if err != nil {
+		logrus.WithError(err).WithField("time", meta["time"]).Debug("Error parsing timestamp")
+		timestamp = time.Now()
+	}
+
+	return &event.Event{
+		Data:      data,
+		Timestamp: timestamp,
+	}
+
+}
+
+func isContinuationLine(line string) bool {
+	return strings.HasPrefix(line, "\t")
+}

--- a/parsers/postgresql/postgresql_test.go
+++ b/parsers/postgresql/postgresql_test.go
@@ -82,7 +82,7 @@ func TestSingleQueryParsing(t *testing.T) {
 		in := make(chan []string)
 		out := make(chan event.Event)
 		p := Parser{}
-		p.Init(&Options{PrefixFormat: tc.prefixFormat})
+		p.Init(&Options{LogLinePrefix: tc.prefixFormat})
 		go p.handleEvents(in, out)
 		in <- strings.Split(tc.in, "\n")
 		close(in)

--- a/parsers/postgresql/postgresql_test.go
+++ b/parsers/postgresql/postgresql_test.go
@@ -1,0 +1,126 @@
+package postgresql
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/honeycombio/honeytail/event"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSingleQueryParsing(t *testing.T) {
+	testcases := []struct {
+		in       string
+		expected event.Event
+	}{
+		{
+			in: `2017-11-07 00:05:16 UTC [3053-3] postgres@postgres LOG:  duration: 0.681 ms  statement: SELECT d.datname as "Name",
+	       pg_catalog.pg_get_userbyid(d.datdba) as "Owner",
+	       pg_catalog.pg_encoding_to_char(d.encoding) as "Encoding",
+	       d.datcollate as "Collate",
+	       d.datctype as "Ctype",
+	       pg_catalog.array_to_string(d.datacl, E'\n') AS "Access privileges"
+	FROM pg_catalog.pg_database d
+	ORDER BY 1;`,
+			expected: event.Event{
+				Timestamp: time.Date(2017, 11, 7, 0, 5, 16, 0, time.UTC),
+				Data: map[string]interface{}{
+					"user":             "postgres",
+					"database":         "postgres",
+					"duration":         0.681,
+					"pid":              3053,
+					"session_id":       3,
+					"query":            "SELECT d.datname as \"Name\", pg_catalog.pg_get_userbyid(d.datdba) as \"Owner\", pg_catalog.pg_encoding_to_char(d.encoding) as \"Encoding\", d.datcollate as \"Collate\", d.datctype as \"Ctype\", pg_catalog.array_to_string(d.datacl, E'\\n') AS \"Access privileges\" FROM pg_catalog.pg_database d ORDER BY 1;",
+					"normalized_query": "select d.datname as ?, pg_catalog.pg_get_userbyid(d.datdba) as ?, pg_catalog.pg_encoding_to_char(d.encoding) as ?, d.datcollate as ?, d.datctype as ?, pg_catalog.array_to_string(d.datacl, e?) as ? from pg_catalog.pg_database d order by ?;",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		in := make(chan []string)
+		out := make(chan event.Event)
+		p := Parser{}
+		p.Init(nil)
+		go p.handleEvents(in, out)
+		in <- strings.Split(tc.in, "\n")
+		close(in)
+		got := <-out
+		assert.Equal(t, got, tc.expected)
+	}
+}
+
+func TestMultipleQueryParsing(t *testing.T) {
+	in := `
+2017-11-07 01:43:18 UTC [3542-5] postgres@test LOG:  duration: 9.263 ms  statement: INSERT INTO test (id, name, value) VALUES (1, 'Alice', 'foo');
+2017-11-07 01:43:27 UTC [3542-6] postgres@test LOG:  duration: 0.841 ms  statement: INSERT INTO test (id, name, value) VALUES (2, 'Bob', 'bar');
+2017-11-07 01:43:39 UTC [3542-7] postgres@test LOG:  duration: 15.577 ms  statement: SELECT * FROM test
+	WHERE id=1;
+2017-11-07 01:43:42 UTC [3542-8] postgres@test LOG:  duration: 0.501 ms  statement: SELECT * FROM test
+	WHERE id=2;
+`
+	out := []event.Event{
+		event.Event{
+			Timestamp: time.Date(2017, 11, 7, 1, 43, 18, 0, time.UTC),
+			Data: map[string]interface{}{
+				"user":             "postgres",
+				"database":         "test",
+				"duration":         9.263,
+				"pid":              3542,
+				"session_id":       5,
+				"query":            "INSERT INTO test (id, name, value) VALUES (1, 'Alice', 'foo');",
+				"normalized_query": "insert into test (id, name, value) values (?, ?, ?);",
+			},
+		},
+		event.Event{
+			Timestamp: time.Date(2017, 11, 7, 1, 43, 27, 0, time.UTC),
+			Data: map[string]interface{}{
+				"user":             "postgres",
+				"database":         "test",
+				"duration":         0.841,
+				"pid":              3542,
+				"session_id":       6,
+				"query":            "INSERT INTO test (id, name, value) VALUES (2, 'Bob', 'bar');",
+				"normalized_query": "insert into test (id, name, value) values (?, ?, ?);",
+			},
+		},
+		event.Event{
+			Timestamp: time.Date(2017, 11, 7, 1, 43, 39, 0, time.UTC),
+			Data: map[string]interface{}{
+				"user":             "postgres",
+				"database":         "test",
+				"duration":         15.577,
+				"pid":              3542,
+				"session_id":       7,
+				"query":            "SELECT * FROM test WHERE id=1;",
+				"normalized_query": "select * from test where id=?;",
+			},
+		},
+		event.Event{
+			Timestamp: time.Date(2017, 11, 7, 1, 43, 42, 0, time.UTC),
+			Data: map[string]interface{}{
+				"user":             "postgres",
+				"database":         "test",
+				"duration":         0.501,
+				"pid":              3542,
+				"session_id":       8,
+				"query":            "SELECT * FROM test WHERE id=2;",
+				"normalized_query": "select * from test where id=?;",
+			},
+		},
+	}
+
+	parser := Parser{}
+	inChan := make(chan string)
+	sendChan := make(chan event.Event, 4)
+	go parser.ProcessLines(inChan, sendChan, nil)
+	for _, line := range strings.Split(in, "\n") {
+		inChan <- line
+	}
+	close(inChan)
+	for _, expected := range out {
+		got := <-sendChan
+		assert.Equal(t, got, expected)
+	}
+}


### PR DESCRIPTION
This is a fairly minimal stab at slurping Postgres query logs. In Postgres,
slow queries go into the general log if you set the
`log_min_duration_statement` setting, and look like this:
```
2017-11-07 01:43:39 UTC [3542-7] postgres@test LOG:  duration: 15.577 ms  statement: SELECT * FROM test WHERE id=1;
```

There are a number of things that I've omitted from this patch for the moment,
in the interest of simplicity:

- Running multiple parser goroutines in parallel.
- Propagating a sample rate down to the parser.
- Verifying compatibility across postgres versions -- I've only tested this
  with PostgreSQL 9.5.
- Parsing log statements that are not slow queries.

I plan to address the first three in subsequent patches, but might punt on
parsing other types of log statements unless there's demonstrated interest.

Note: this looks like a monster diff, but it includes (and depends on) #58 and #71. Only the latest commit is the relevant one. 