### PR TITLE
Use `context` instead of our own `abort` channel to signal

### DIFF
--- a/leash.go
+++ b/leash.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"math/rand"
@@ -37,7 +38,7 @@ func run(options GlobalOptions) {
 	stats := newResponseStats()
 
 	sigs := make(chan os.Signal, 1)
-	abort := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
 	// spin up our transmission to send events to Honeycomb
@@ -81,9 +82,9 @@ func run(options GlobalOptions) {
 		Options: options.Tail,
 	}
 	if options.TailSample {
-		linesChans, err = tail.GetSampledEntries(tc, options.SampleRate, abort)
+		linesChans, err = tail.GetSampledEntries(ctx, tc, options.SampleRate)
 	} else {
-		linesChans, err = tail.GetEntries(tc, abort)
+		linesChans, err = tail.GetEntries(ctx, tc)
 	}
 	if err != nil {
 		logrus.WithFields(logrus.Fields{"err": err}).Fatal(
@@ -96,7 +97,7 @@ func run(options GlobalOptions) {
 		sig := <-sigs
 		fmt.Fprintf(os.Stderr, "Aborting! Caught signal \"%s\"\n", sig)
 		fmt.Fprintf(os.Stderr, "Cleaning up...\n")
-		close(abort)
+		cancel()
 		// and if they insist, catch a second CTRL-C or timeout on 10sec
 		select {
 		case <-sigs:
@@ -156,7 +157,7 @@ func run(options GlobalOptions) {
 
 		// start up the sender. all sources are either sampled when tailing or in-
 		// parser, so always tell libhoney events are pre-sampled
-		go sendToLibhoney(realToBeSent, toBeResent, delaySending, doneSending)
+		go sendToLibhoney(ctx, realToBeSent, toBeResent, delaySending, doneSending)
 
 		// start a goroutine that reads from responses and logs.
 		responses := libhoney.Responses()
@@ -414,7 +415,7 @@ func whitelistKey(whiteKeys []string, key string) bool {
 
 // sendToLibhoney reads from the toBeSent channel and shoves the events into
 // libhoney events, sending them on their way.
-func sendToLibhoney(toBeSent chan event.Event, toBeResent chan event.Event,
+func sendToLibhoney(ctx context.Context, toBeSent chan event.Event, toBeResent chan event.Event,
 	delaySending chan int, doneSending chan bool) {
 	for {
 		// check and see if we need to back off the API because of rate limiting
@@ -434,6 +435,9 @@ func sendToLibhoney(toBeSent chan event.Event, toBeResent chan event.Event,
 		}
 		// otherwise pick something up off the regular queue and send it
 		select {
+		case <-ctx.Done():
+			doneSending <- true
+			return
 		case ev, ok := <-toBeSent:
 			if !ok {
 				// channel is closed

--- a/leash.go
+++ b/leash.go
@@ -434,9 +434,6 @@ func sendToLibhoney(ctx context.Context, toBeSent chan event.Event, toBeResent c
 		}
 		// otherwise pick something up off the regular queue and send it
 		select {
-		case <-ctx.Done():
-			doneSending <- true
-			return
 		case ev, ok := <-toBeSent:
 			if !ok {
 				// channel is closed

--- a/leash.go
+++ b/leash.go
@@ -91,8 +91,7 @@ func run(options GlobalOptions) {
 			"Error occurred while trying to tail logfile")
 	}
 
-	// set up our signal handler, now that we know how many files we're tailing,
-	// we can send the right number of abort signals.
+	// set up our signal handler and support canceling
 	go func() {
 		sig := <-sigs
 		fmt.Fprintf(os.Stderr, "Aborting! Caught signal \"%s\"\n", sig)


### PR DESCRIPTION
Precursor work to some honeytail telemetry work -- use `context.Context`s instead.

I also added a `<-ctx.Done():` inside `sendToLibhoney` so that we're not hanging on clearing a send queue when we get a signal. (Happy to be pushed back with the concern that we'd drop events on the floor in the case of an intentional pause / intent to resume, but it feels like most folks at this point are just `CTRL-C`'ing and want the thing to stop. Shrug.)