### PR TITLE
Support opt-in telemetry sent to a `-reports` dataset

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -4,7 +4,8 @@ package event
 
 import "time"
 
-// Event is a single log event
+// Event is a single log event that we use in lieu of libhoney.Event because it
+// supports manipulation of the Data map (e.g. for scrubbing/manipulation)
 type Event struct {
 	// Timestamp is the time of the event (may be different from current time)
 	Timestamp time.Time

--- a/leash.go
+++ b/leash.go
@@ -465,7 +465,7 @@ func sendEvent(ev event.Event) {
 		// drop the event!
 		logrus.WithFields(logrus.Fields{
 			"event": ev,
-		}).Debug("droppped event due to sampling")
+		}).Debug("Skipped: dropped event due to sampling")
 		return
 	}
 	libhEv := libhoney.NewEvent()
@@ -510,7 +510,6 @@ func handleResponses(responses chan libhoney.Response, stats *responseStats,
 		} else {
 			logfields["retry_send"] = false
 		}
-		logrus.WithFields(logfields).Debug("event send record received")
 	}
 }
 

--- a/leash_test.go
+++ b/leash_test.go
@@ -42,8 +42,7 @@ var defaultOptions = GlobalOptions{
 		// LogFiles:   []string{tmpdir + ""},
 		Dataset: "pika",
 	},
-	Tail:           tailOptions,
-	StatusInterval: 1,
+	Tail: tailOptions,
 }
 
 // test testing framework

--- a/main.go
+++ b/main.go
@@ -44,56 +44,55 @@ var validParsers = []string{
 
 // GlobalOptions has all the top level CLI flags that honeytail supports
 type GlobalOptions struct {
-	APIHost    string `hidden:"true" long:"api_host" description:"Host for the Honeycomb API" default:"https://api.honeycomb.io/"`
-	TailSample bool   `hidden:"true" description:"When true, sample while tailing. When false, sample post-parser events"`
+	APIHost    string `hidden:"true" long:"api_host" description:"Host for the Honeycomb API" default:"https://api.honeycomb.io/" json:",omitempty"`
+	TailSample bool   `hidden:"true" description:"When true, sample while tailing. When false, sample post-parser events" json:",omitempty"`
 
-	ConfigFile string `short:"c" long:"config" description:"Config file for honeytail in INI format." no-ini:"true"`
+	ConfigFile string `short:"c" long:"config" description:"Config file for honeytail in INI format." no-ini:"true" json:",omitempty"`
 
-	SampleRate       uint `short:"r" long:"samplerate" description:"Only send 1 / N log lines" default:"1"`
-	NumSenders       uint `short:"P" long:"poolsize" description:"Number of concurrent connections to open to Honeycomb" default:"80"`
-	BatchFrequencyMs uint `long:"send_frequency_ms" description:"How frequently to flush batches" default:"100"`
-	BatchSize        uint `long:"send_batch_size" description:"Maximum number of messages to put in a batch" default:"50"`
-	Debug            bool `long:"debug" description:"Print debugging output"`
-	StatusInterval   uint `long:"status_interval" description:"How frequently, in seconds, to print out summary info" default:"60"`
-	Backfill         bool `long:"backfill" description:"Configure honeytail to ingest old data in order to backfill Honeycomb. Sets the correct values for --backoff, --tail.read_from, and --tail.stop"`
+	SampleRate       uint `short:"r" long:"samplerate" description:"Only send 1 / N log lines" default:"1" json:",omitempty"`
+	NumSenders       uint `short:"P" long:"poolsize" description:"Number of concurrent connections to open to Honeycomb" default:"80" json:",omitempty"`
+	BatchFrequencyMs uint `long:"send_frequency_ms" description:"How frequently to flush batches" default:"100" json:",omitempty"`
+	BatchSize        uint `long:"send_batch_size" description:"Maximum number of messages to put in a batch" default:"50" json:",omitempty"`
+	Backfill         bool `long:"backfill" description:"Configure honeytail to ingest old data in order to backfill Honeycomb. Sets the correct values for --backoff, --tail.read_from, and --tail.stop" json:",omitempty"`
 
-	Localtime         bool     `long:"localtime" description:"When parsing a timestamp that has no time zone, assume it is in the same timezone as localhost instead of UTC (the default)"`
-	Timezone          string   `long:"timezone" description:"When parsing a timestamp use this time zone instead of UTC (the default). Must be specified in TZ format as seen here: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones"`
-	ScrubFields       []string `long:"scrub_field" description:"For the field listed, apply a one-way hash to the field content. May be specified multiple times"`
-	DropFields        []string `long:"drop_field" description:"Do not send the field to Honeycomb. May be specified multiple times"`
-	AddFields         []string `long:"add_field" description:"Add the field to every event. Field should be key=val. May be specified multiple times"`
-	RequestShape      []string `long:"request_shape" description:"Identify a field that contains an HTTP request of the form 'METHOD /path HTTP/1.x' or just the request path. Break apart that field into subfields that contain components. May be specified multiple times. Defaults to 'request' when using the nginx parser"`
-	ShapePrefix       string   `long:"shape_prefix" description:"Prefix to use on fields generated from request_shape to prevent field collision"`
-	RequestPattern    []string `long:"request_pattern" description:"A pattern for the request path on which to base the derived request_shape. May be specified multiple times. Patterns are considered in order; first match wins."`
-	RequestParseQuery string   `long:"request_parse_query" description:"How to parse the request query parameters. 'whitelist' means only extract listed query keys. 'all' means to extract all query parameters as individual columns" default:"whitelist"`
-	RequestQueryKeys  []string `long:"request_query_keys" description:"Request query parameter key names to extract, when request_parse_query is 'whitelist'. May be specified multiple times."`
-	BackOff           bool     `long:"backoff" description:"When rate limited by the API, back off and retry sending failed events. Otherwise failed events are dropped. When --backfill is set, it will override this option=true"`
-	PrefixRegex       string   `long:"log_prefix" description:"pass a regex to this flag to strip the matching prefix from the line before handing to the parser. Useful when log aggregation prepends a line header. Use named groups to extract fields into the event."`
-	DynSample         []string `long:"dynsampling" description:"enable dynamic sampling using the field listed in this option. May be specified multiple times; fields will be concatenated to form the dynsample key. WARNING increases CPU utilization dramatically over normal sampling"`
-	DynWindowSec      int      `long:"dynsample_window" description:"measurement window size for the dynsampler, in seconds" default:"30"`
-	GoalSampleRate    int      `hidden:"true" description:"used to hold the desired sample rate and set tailing sample rate to 1"`
-	MinSampleRate     int      `long:"dynsample_minimum" description:"if the rate of traffic falls below this, dynsampler won't sample" default:"1"`
+	Localtime         bool     `long:"localtime" description:"When parsing a timestamp that has no time zone, assume it is in the same timezone as localhost instead of UTC (the default)" json:",omitempty"`
+	Timezone          string   `long:"timezone" description:"When parsing a timestamp use this time zone instead of UTC (the default). Must be specified in TZ format as seen here: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones" json:",omitempty"`
+	ScrubFields       []string `long:"scrub_field" description:"For the field listed, apply a one-way hash to the field content. May be specified multiple times" json:",omitempty"`
+	DropFields        []string `long:"drop_field" description:"Do not send the field to Honeycomb. May be specified multiple times" json:",omitempty"`
+	AddFields         []string `long:"add_field" description:"Add the field to every event. Field should be key=val. May be specified multiple times" json:",omitempty"`
+	RequestShape      []string `long:"request_shape" description:"Identify a field that contains an HTTP request of the form 'METHOD /path HTTP/1.x' or just the request path. Break apart that field into subfields that contain components. May be specified multiple times. Defaults to 'request' when using the nginx parser" json:",omitempty"`
+	ShapePrefix       string   `long:"shape_prefix" description:"Prefix to use on fields generated from request_shape to prevent field collision" json:",omitempty"`
+	RequestPattern    []string `long:"request_pattern" description:"A pattern for the request path on which to base the derived request_shape. May be specified multiple times. Patterns are considered in order; first match wins." json:",omitempty"`
+	RequestParseQuery string   `long:"request_parse_query" description:"How to parse the request query parameters. 'whitelist' means only extract listed query keys. 'all' means to extract all query parameters as individual columns" default:"whitelist" json:",omitempty"`
+	RequestQueryKeys  []string `long:"request_query_keys" description:"Request query parameter key names to extract, when request_parse_query is 'whitelist'. May be specified multiple times." json:",omitempty"`
+	BackOff           bool     `long:"backoff" description:"When rate limited by the API, back off and retry sending failed events. Otherwise failed events are dropped. When --backfill is set, it will override this option=true" json:",omitempty"`
+	PrefixRegex       string   `long:"log_prefix" description:"pass a regex to this flag to strip the matching prefix from the line before handing to the parser. Useful when log aggregation prepends a line header. Use named groups to extract fields into the event." json:",omitempty"`
+	DynSample         []string `long:"dynsampling" description:"enable dynamic sampling using the field listed in this option. May be specified multiple times; fields will be concatenated to form the dynsample key. WARNING increases CPU utilization dramatically over normal sampling" json:",omitempty"`
+	DynWindowSec      int      `long:"dynsample_window" description:"measurement window size for the dynsampler, in seconds" default:"30" json:",omitempty"`
+	GoalSampleRate    int      `hidden:"true" description:"used to hold the desired sample rate and set tailing sample rate to 1" json:",omitempty"`
+	MinSampleRate     int      `long:"dynsample_minimum" description:"if the rate of traffic falls below this, dynsampler won't sample" default:"1" json:",omitempty"`
 
-	Reqs  RequiredOptions `group:"Required Options"`
-	Modes OtherModes      `group:"Other Modes"`
+	Reqs   RequiredOptions  `group:"Required Options" json:",omitempty"`
+	Report ReportingOptions `group:"Reporting Options" json:",omitempty"` // TODO: feedback on naming
+	Modes  OtherModes       `group:"Other Modes" json:"-"`
 
-	Tail tail.TailOptions `group:"Tail Options" namespace:"tail"`
+	Tail tail.TailOptions `group:"Tail Options" namespace:"tail" json:",omitempty"`
 
-	ArangoDB   arangodb.Options   `group:"ArangoDB Parser Options" namespace:"arangodb"`
-	JSON       htjson.Options     `group:"JSON Parser Options" namespace:"json"`
-	KeyVal     keyval.Options     `group:"KeyVal Parser Options" namespace:"keyval"`
-	Mongo      mongodb.Options    `group:"MongoDB Parser Options" namespace:"mongo"`
-	MySQL      mysql.Options      `group:"MySQL Parser Options" namespace:"mysql"`
-	Nginx      nginx.Options      `group:"Nginx Parser Options" namespace:"nginx"`
+	ArangoDB   arangodb.Options   `group:"ArangoDB Parser Options" namespace:"arangodb" json:",omitempty"`
+	JSON       htjson.Options     `group:"JSON Parser Options" namespace:"json" json:",omitempty"`
+	KeyVal     keyval.Options     `group:"KeyVal Parser Options" namespace:"keyval" json:",omitempty"`
+	Mongo      mongodb.Options    `group:"MongoDB Parser Options" namespace:"mongo" json:",omitempty"`
+	MySQL      mysql.Options      `group:"MySQL Parser Options" namespace:"mysql" json:",omitempty"`
+	Nginx      nginx.Options      `group:"Nginx Parser Options" namespace:"nginx" json:",omitempty"`
 	PostgreSQL postgresql.Options `group:"PostgreSQL Parser Options" namespace:"postgresql"`
 	Regex      regex.Options      `group:"Regex Parser Options" namespace:"regex"`
 }
 
 type RequiredOptions struct {
-	ParserName string   `short:"p" long:"parser" description:"Parser module to use. Use --list to list available options."`
-	WriteKey   string   `short:"k" long:"writekey" description:"Team write key"`
-	LogFiles   []string `short:"f" long:"file" description:"Log file(s) to parse. Use '-' for STDIN, use this flag multiple times to tail multiple files, or use a glob (/path/to/foo-*.log)"`
-	Dataset    string   `short:"d" long:"dataset" description:"Name of the dataset"`
+	ParserName string   `short:"p" long:"parser" description:"Parser module to use. Use --list to list available options." json:",omitempty"`
+	WriteKey   string   `short:"k" long:"writekey" description:"Team write key" json:"-"`
+	LogFiles   []string `short:"f" long:"file" description:"Log file(s) to parse. Use '-' for STDIN, use this flag multiple times to tail multiple files, or use a glob (/path/to/foo-*.log)" json:",omitempty"`
+	Dataset    string   `short:"d" long:"dataset" description:"Name of the dataset" json:"-"`
 }
 
 type OtherModes struct {
@@ -104,6 +103,12 @@ type OtherModes struct {
 	WriteCurrentConfig bool `long:"write_current_config" description:"Write out the current config to STDOUT" no-ini:"true"`
 
 	WriteManPage bool `hidden:"true" long:"write-man-page" description:"Write out a man page"`
+}
+
+type ReportingOptions struct {
+	Debug          bool `long:"debug" description:"Print debugging output" json:",omitempty"`
+	StatusInterval uint `long:"status_interval" description:"How frequently, in seconds, to print out summary info" default:"60" json:",omitempty"`
+	Telemetry      bool `long:"report" description:"Report honeytail debug output back to Honeycomb, in a parallel dataset TODO CLEAN ME UP" json:",omitempty"`
 }
 
 func main() {
@@ -135,7 +140,7 @@ func main() {
 
 	rand.Seed(time.Now().UnixNano())
 
-	if options.Debug {
+	if options.Report.Debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 

--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ type OtherModes struct {
 type ReportingOptions struct {
 	Debug          bool `long:"debug" description:"Print debugging output" json:",omitempty"`
 	StatusInterval uint `long:"status_interval" description:"How frequently, in seconds, to print out summary info" default:"60" json:",omitempty"`
-	Telemetry      bool `long:"report" description:"Report honeytail debug output back to Honeycomb, in a parallel dataset TODO CLEAN ME UP" json:",omitempty"`
+	Telemetry      bool `long:"report" description:"Report honeytail debug output back to Honeycomb, in a parallel (sampled) dataset" json:",omitempty"`
 }
 
 func main() {

--- a/parsers/arangodb/arangodb.go
+++ b/parsers/arangodb/arangodb.go
@@ -187,7 +187,10 @@ func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, pref
 				if err == nil {
 					timestamp, err := p.parseTimestamp(values)
 					if err != nil {
-						logSkipped(line, "couldn't parse logline timestamp, skipping")
+						logrus.WithFields(logrus.Fields{
+							"line":  line,
+							"error": err,
+						}).Debugln("Skipped: couldn't parse log line timestamp")
 						continue
 					}
 
@@ -197,9 +200,10 @@ func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, pref
 					}
 
 					logrus.WithFields(logrus.Fields{
-						"line":   line,
-						"values": values,
-					}).Debug("Successfully parsed line")
+						"line":      line,
+						"values":    values,
+						"timestamp": timestamp,
+					}).Debug("Success: parsed line")
 
 					// we'll be putting the timestamp in the Event
 					// itself, no need to also have it in the Data
@@ -210,7 +214,10 @@ func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, pref
 						Data:      values,
 					}
 				} else {
-					logSkipped(line, "logline didn't parse, skipping.")
+					logrus.WithFields(logrus.Fields{
+						"line":  line,
+						"error": err,
+					}).Debugln("Skipped: log line failed to parse")
 				}
 			}
 			wg.Done()
@@ -234,9 +241,5 @@ func (p *Parser) parseTimestamp(values map[string]interface{}) (time.Time, error
 		return time.Time{}, err
 	}
 
-	return time.Time{}, errors.New("timestamp missing from logline")
-}
-
-func logSkipped(line string, msg string) {
-	logrus.WithFields(logrus.Fields{"line": line}).Debugln(msg)
+	return time.Time{}, errors.New("timestamp missing from log line")
 }

--- a/parsers/arangodb/arangodb_test.go
+++ b/parsers/arangodb/arangodb_test.go
@@ -1,6 +1,7 @@
 package arangodb
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -81,7 +82,7 @@ func TestProcessLines(t *testing.T) {
 		close(lines)
 	}()
 	// spin up the processor to process our test lines
-	go m.ProcessLines(lines, send, nil)
+	go m.ProcessLines(context.TODO(), lines, send, nil)
 	for _, pair := range tlm {
 		ev := <-send
 

--- a/parsers/keyval/keyval_test.go
+++ b/parsers/keyval/keyval_test.go
@@ -1,6 +1,7 @@
 package keyval
 
 import (
+	"context"
 	"reflect"
 	"sync"
 	"testing"
@@ -143,7 +144,7 @@ func TestFilterRegex(t *testing.T) {
 			}
 			wg.Done()
 		}()
-		p.ProcessLines(lines, send, nil)
+		p.ProcessLines(context.TODO(), lines, send, nil)
 		close(send)
 		wg.Wait()
 	}
@@ -174,7 +175,7 @@ func TestDontReturnEmptyEvents(t *testing.T) {
 		}
 		wg.Done()
 	}()
-	p.ProcessLines(lines, send, nil)
+	p.ProcessLines(context.TODO(), lines, send, nil)
 	close(send)
 	wg.Wait()
 }
@@ -206,7 +207,7 @@ func TestDontReturnUselessEvents(t *testing.T) {
 		}
 		wg.Done()
 	}()
-	p.ProcessLines(lines, send, nil)
+	p.ProcessLines(context.TODO(), lines, send, nil)
 	close(send)
 	wg.Wait()
 }

--- a/parsers/mongodb/mongodb_test.go
+++ b/parsers/mongodb/mongodb_test.go
@@ -1,6 +1,7 @@
 package mongodb
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -430,7 +431,7 @@ func TestProcessLines(t *testing.T) {
 		close(lines)
 	}()
 	// spin up the processor to process our test lines
-	go m.ProcessLines(lines, send, nil)
+	go m.ProcessLines(context.TODO(), lines, send, nil)
 	for range tlm {
 		ev := <-send
 		var found bool

--- a/parsers/mysql/mysql.go
+++ b/parsers/mysql/mysql.go
@@ -429,7 +429,7 @@ func (p *Parser) handleEvent(ptp *perThreadParser, rawE []string) (
 			logrus.WithFields(logrus.Fields{
 				"line":  line,
 				"event": rawE,
-			}).Debug("readmin ping detected; skipping this event")
+			}).Debug("Skipped: detected administrator ping")
 			return nil, time.Time{}
 		} else if _, mg := reUser.FindStringSubmatchMap(line); mg != nil {
 			query = ""
@@ -541,7 +541,7 @@ func (p *Parser) handleEvent(ptp *perThreadParser, rawE []string) (
 			// unknown row; log and skip
 			logrus.WithFields(logrus.Fields{
 				"line": line,
-			}).Debug("No regex match for line in the middle of a query. skipping")
+			}).Debug("Skipped: no regex match for line in the middle of a query")
 		}
 	}
 
@@ -563,6 +563,12 @@ func (p *Parser) handleEvent(ptp *perThreadParser, rawE []string) (
 	} else if timeFromSet > 0 {
 		combinedTime = time.Unix(timeFromSet, 0)
 	}
+
+	logrus.WithFields(logrus.Fields{
+		"lines":     rawE,
+		"values":    sq,
+		"timestamp": combinedTime,
+	}).Debug("Success: parsed lines")
 
 	return sq, combinedTime
 }

--- a/parsers/mysql/mysql_test.go
+++ b/parsers/mysql/mysql_test.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math/rand"
@@ -597,7 +598,7 @@ func TestHandleEvent(t *testing.T) {
 		normalizer: &normalizer.Parser{},
 	}
 	for i, sqd := range sqds {
-		res, timestamp := p.handleEvent(ptp, sqd.rawE)
+		res, timestamp := p.handleEvent(context.TODO(), ptp, sqd.rawE)
 		if len(res) != len(sqd.sq) {
 			t.Errorf("case num %d: expected to parse %d fields, got %d", i, len(sqd.sq), len(res))
 			fmt.Printf("res is %+v\n", res)
@@ -638,7 +639,7 @@ func TestTimeProcessing(t *testing.T) {
 	}
 
 	for _, tt := range tsts {
-		_, timestamp := p.handleEvent(ptp, tt.lines)
+		_, timestamp := p.handleEvent(context.TODO(), ptp, tt.lines)
 		if timestamp.Unix() != tt.expected.Unix() {
 			t.Errorf("Didn't capture unix ts from lines:\n%+v\n\tExpected: %d, Actual: %d",
 				strings.Join(tt.lines, "\n"), tt.expected.Unix(), timestamp.Unix())
@@ -850,7 +851,7 @@ func TestProcessLines(t *testing.T) {
 		lines := make(chan string, 10)
 		send := make(chan event.Event, 5)
 		go func() {
-			p.ProcessLines(lines, send, nil)
+			p.ProcessLines(context.TODO(), lines, send, nil)
 			close(send)
 		}()
 		for _, line := range tt.in {
@@ -890,7 +891,7 @@ func TestProcessLines(t *testing.T) {
 		lines := make(chan string, 10)
 		send := make(chan event.Event, 5)
 		go func() {
-			p.ProcessLines(lines, send, nil)
+			p.ProcessLines(context.TODO(), lines, send, nil)
 			close(send)
 		}()
 		for _, line := range tt.in {

--- a/parsers/nginx/nginx.go
+++ b/parsers/nginx/nginx.go
@@ -64,9 +64,6 @@ type GonxLineParser struct {
 func (g *GonxLineParser) ParseLine(line string) (map[string]interface{}, error) {
 	gonxEvent, err := g.parser.ParseString(line)
 	if err != nil {
-		logrus.WithFields(logrus.Fields{
-			"logline": line,
-		}).Debug("failed to parse nginx log line")
 		return nil, err
 	}
 	return typeifyParsedLine(gonxEvent.Fields), nil
@@ -80,9 +77,6 @@ func (n *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, pref
 		go func() {
 			for line := range lines {
 				line = strings.TrimSpace(line)
-				logrus.WithFields(logrus.Fields{
-					"line": line,
-				}).Debug("Attempting to process nginx log line")
 
 				// take care of any headers on the line
 				var prefixFields map[string]interface{}
@@ -95,6 +89,10 @@ func (n *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, pref
 
 				parsedLine, err := n.lineParser.ParseLine(line)
 				if err != nil {
+					logrus.WithFields(logrus.Fields{
+						"line":  line,
+						"error": err,
+					}).Debugln("Skipped: log line failed to parse")
 					continue
 				}
 				// merge the prefix fields and the parsed line contents
@@ -102,6 +100,12 @@ func (n *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, pref
 					parsedLine[k] = v
 				}
 				timestamp := n.getTimestamp(parsedLine)
+
+				logrus.WithFields(logrus.Fields{
+					"line":      line,
+					"values":    parsedLine,
+					"timestamp": timestamp,
+				}).Debugln("Success: parsed line")
 
 				e := event.Event{
 					Timestamp: timestamp,

--- a/parsers/nginx/nginx_test.go
+++ b/parsers/nginx/nginx_test.go
@@ -1,6 +1,7 @@
 package nginx
 
 import (
+	"context"
 	"log"
 	"reflect"
 	"regexp"
@@ -64,7 +65,7 @@ func TestProcessLines(t *testing.T) {
 		}
 		close(lines)
 	}()
-	go p.ProcessLines(lines, send, preReg)
+	go p.ProcessLines(context.TODO(), lines, send, preReg)
 	for _, pair := range tlm {
 		resp := <-send
 		if !reflect.DeepEqual(resp, pair.ev) {
@@ -108,7 +109,7 @@ func TestProcessLinesNoPreReg(t *testing.T) {
 		}
 		close(lines)
 	}()
-	go p.ProcessLines(lines, send, nil)
+	go p.ProcessLines(context.TODO(), lines, send, nil)
 	for _, pair := range tlm {
 		resp := <-send
 		if !reflect.DeepEqual(resp, pair.ev) {

--- a/parsers/parsers.go
+++ b/parsers/parsers.go
@@ -4,7 +4,11 @@
 // any necessary or relevant smarts for that style of logs.
 package parsers
 
-import "github.com/honeycombio/honeytail/event"
+import (
+	"context"
+
+	"github.com/honeycombio/honeytail/event"
+)
 
 type Parser interface {
 	// Init does any initialization necessary for the module
@@ -12,7 +16,7 @@ type Parser interface {
 	// ProcessLines consumes log lines from the lines channel and sends log events
 	// to the send channel. prefixRegex, if not nil, will be stripped from the
 	// line prior to parsing. Any named groups will be added to the event.
-	ProcessLines(lines <-chan string, send chan<- event.Event, prefixRegex *ExtRegexp)
+	ProcessLines(ctx context.Context, lines <-chan string, send chan<- event.Event, prefixRegex *ExtRegexp)
 }
 
 type LineParser interface {

--- a/parsers/postgresql/postgresql.go
+++ b/parsers/postgresql/postgresql.go
@@ -50,6 +50,7 @@
 package postgresql
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -124,7 +125,7 @@ func (p *Parser) Init(options interface{}) (err error) {
 	return err
 }
 
-func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, prefixRegex *parsers.ExtRegexp) {
+func (p *Parser) ProcessLines(ctx context.Context, lines <-chan string, send chan<- event.Event, prefixRegex *parsers.ExtRegexp) {
 	rawEvents := make(chan []string)
 	wg := &sync.WaitGroup{}
 	wg.Add(1)

--- a/parsers/postgresql/postgresql_test.go
+++ b/parsers/postgresql/postgresql_test.go
@@ -1,6 +1,7 @@
 package postgresql
 
 import (
+	"context"
 	"strings"
 	"sync"
 	"testing"
@@ -165,7 +166,7 @@ func TestMultipleQueryParsing(t *testing.T) {
 	parser.Init(nil)
 	inChan := make(chan string)
 	sendChan := make(chan event.Event, 4)
-	go parser.ProcessLines(inChan, sendChan, nil)
+	go parser.ProcessLines(context.TODO(), inChan, sendChan, nil)
 	for _, line := range strings.Split(in, "\n") {
 		inChan <- line
 	}

--- a/parsers/regex/regex_test.go
+++ b/parsers/regex/regex_test.go
@@ -1,6 +1,7 @@
 package regex
 
 import (
+	"context"
 	"reflect"
 	"regexp"
 	"testing"
@@ -265,7 +266,7 @@ func TestProcessLines(t *testing.T) {
 		}
 		close(lines)
 	}()
-	go p.ProcessLines(lines, send, preReg)
+	go p.ProcessLines(context.TODO(), lines, send, preReg)
 	for _, pair := range tlm {
 		resp := <-send
 		if !reflect.DeepEqual(resp, pair.ev) {

--- a/reporting/reporting.go
+++ b/reporting/reporting.go
@@ -2,6 +2,7 @@ package reporting
 
 import (
 	"context"
+	"os"
 	"strings"
 	"time"
 
@@ -21,9 +22,13 @@ const (
 func NewContext(ctx context.Context) context.Context {
 	builder := libhoney.NewBuilder()
 	builder.Dataset += reportingSuffix
+	if hostname, err := os.Hostname(); err == nil {
+		builder.AddField("hostname", hostname)
+	}
+
 	sampler := &dynsampler.PerKeyThroughput{
 		ClearFrequencySec:      1,
-		PerKeyThroughputPerSec: 1000,
+		PerKeyThroughputPerSec: 10,
 	}
 	ctx = context.WithValue(ctx, contextKeyBuilder, builder)
 	if err := sampler.Start(); err != nil {

--- a/reporting/reporting.go
+++ b/reporting/reporting.go
@@ -2,7 +2,6 @@ package reporting
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"time"
 
@@ -19,16 +18,13 @@ const (
 
 func NewContext(ctx context.Context) context.Context {
 	builder := libhoney.NewBuilder()
+	builder.Dataset += reportingSuffix
 	return context.WithValue(ctx, contextKeyBuilder, builder)
 }
 
 func Options(ctx context.Context, options interface{}) {
 	if ev := getEvent(ctx); ev != nil {
-		optj, err := json.Marshal(options)
-		if err != nil {
-			return
-		}
-		ev.AddField("config_json", string(optj))
+		ev.AddField("config_json", options)
 		ev.Send()
 	}
 }
@@ -121,7 +117,5 @@ func getEvent(ctx context.Context) *libhoney.Event {
 		return nil
 	}
 
-	ev := builder.NewEvent()
-	ev.Dataset += reportingSuffix
-	return ev
+	return builder.NewEvent()
 }

--- a/reporting/reporting.go
+++ b/reporting/reporting.go
@@ -6,31 +6,42 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/honeycombio/dynsampler-go"
 	"github.com/honeycombio/libhoney-go"
 
 	"github.com/honeycombio/honeytail/event"
 )
 
 const (
-	contextKeyBuilder = "reporting"
+	contextKeyBuilder = "builder"
+	contextKeySampler = "sampler"
 	reportingSuffix   = "-reports"
 )
 
 func NewContext(ctx context.Context) context.Context {
 	builder := libhoney.NewBuilder()
 	builder.Dataset += reportingSuffix
-	return context.WithValue(ctx, contextKeyBuilder, builder)
+	sampler := &dynsampler.PerKeyThroughput{
+		ClearFrequencySec:      1,
+		PerKeyThroughputPerSec: 1000,
+	}
+	ctx = context.WithValue(ctx, contextKeyBuilder, builder)
+	if err := sampler.Start(); err != nil {
+		logrus.WithField("error", err).Error("Unexpected error initializing dynamic sampler")
+		return ctx
+	}
+	return context.WithValue(ctx, contextKeySampler, sampler)
 }
 
 func Options(ctx context.Context, options interface{}) {
-	if ev := getEvent(ctx); ev != nil {
+	if ev := getEvent(ctx, "options"); ev != nil {
 		ev.AddField("config_json", options)
 		ev.Send()
 	}
 }
 
 func TailState(ctx context.Context, file string, inode uint64, offset int64, size int64) {
-	if ev := getEvent(ctx); ev != nil {
+	if ev := getEvent(ctx, "tail snapshot"); ev != nil {
 		ev.AddField("tail_filename", file)
 		ev.AddField("tail_inode", inode)
 		ev.AddField("tail_offset", offset)
@@ -46,7 +57,7 @@ func ParseError(ctx context.Context, line string, err error) {
 		"error": err,
 	}).Debugln("Skipped: log line failed to parse")
 
-	if ev := getEvent(ctx); ev != nil {
+	if ev := getEvent(ctx, "parse error"); ev != nil {
 		ev.AddField("log_line", line)
 		ev.AddField("parse_error", err.Error())
 		ev.Send()
@@ -60,7 +71,7 @@ func Skip(ctx context.Context, line, skipReason string) {
 func SkipWithFields(ctx context.Context, line, skipReason string, fields logrus.Fields) {
 	logrus.WithFields(fields).WithField("line", line).Debugln("Skipped:", skipReason)
 
-	if ev := getEvent(ctx); ev != nil {
+	if ev := getEvent(ctx, "skip"); ev != nil {
 		ev.AddField("log_line", line)
 		ev.AddField("skip_reason", skipReason)
 		ev.Send()
@@ -73,7 +84,7 @@ func SendError(ctx context.Context, sentEvent *event.Event, err error) {
 		"error": err,
 	}).Error("Unexpected error when sending to Honeycomb")
 
-	if ev := getEvent(ctx); ev != nil {
+	if ev := getEvent(ctx, "send error"); ev != nil {
 		ev.AddField("event_timestamp", sentEvent.Timestamp)
 		ev.AddField("event_timestamp_lag_sec", time.Since(sentEvent.Timestamp)/time.Second)
 		ev.AddField("event_data", sentEvent.Data)
@@ -90,7 +101,7 @@ func Response(ctx context.Context, rsp *libhoney.Response, willRetry bool) {
 		"error":       rsp.Err,
 	}).Debug("Server response")
 
-	if ev := getEvent(ctx); ev != nil {
+	if ev := getEvent(ctx, "response"); ev != nil {
 		defer func() {
 			// If we've called libhoney.Close(), response handling will still
 			// happen - and we should be fine with just tossing away telemetry
@@ -111,11 +122,16 @@ func Response(ctx context.Context, rsp *libhoney.Response, willRetry bool) {
 	}
 }
 
-func getEvent(ctx context.Context) *libhoney.Event {
+func getEvent(ctx context.Context, key string) *libhoney.Event {
 	builder, ok := ctx.Value(contextKeyBuilder).(*libhoney.Builder)
 	if !ok { // will bail if not configured to report
 		return nil
 	}
 
-	return builder.NewEvent()
+	ev := builder.NewEvent()
+	if sampler, ok := ctx.Value(contextKeySampler).(dynsampler.Sampler); ok {
+		ev.SampleRate = uint(sampler.GetSampleRate(key))
+	}
+
+	return ev
 }

--- a/reporting/reporting.go
+++ b/reporting/reporting.go
@@ -1,0 +1,127 @@
+package reporting
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/honeycombio/libhoney-go"
+
+	"github.com/honeycombio/honeytail/event"
+)
+
+const (
+	contextKeyBuilder = "reporting"
+	reportingSuffix   = "-reports"
+)
+
+func NewContext(ctx context.Context) context.Context {
+	builder := libhoney.NewBuilder()
+	return context.WithValue(ctx, contextKeyBuilder, builder)
+}
+
+func Options(ctx context.Context, options interface{}) {
+	if ev := getEvent(ctx); ev != nil {
+		optj, err := json.Marshal(options)
+		if err != nil {
+			return
+		}
+		ev.AddField("config_json", string(optj))
+		ev.Send()
+	}
+}
+
+func TailState(ctx context.Context, file string, inode uint64, offset int64, size int64) {
+	if ev := getEvent(ctx); ev != nil {
+		ev.AddField("tail_filename", file)
+		ev.AddField("tail_inode", inode)
+		ev.AddField("tail_offset", offset)
+		ev.AddField("tail_filesize", size)
+		ev.AddField("pct_processed", float64(offset)/float64(size)*100)
+		ev.Send()
+	}
+}
+
+func ParseError(ctx context.Context, line string, err error) {
+	logrus.WithFields(logrus.Fields{
+		"line":  line,
+		"error": err,
+	}).Debugln("Skipped: log line failed to parse")
+
+	if ev := getEvent(ctx); ev != nil {
+		ev.AddField("log_line", line)
+		ev.AddField("parse_error", err.Error())
+		ev.Send()
+	}
+}
+
+func Skip(ctx context.Context, line, skipReason string) {
+	SkipWithFields(ctx, line, skipReason, nil)
+}
+
+func SkipWithFields(ctx context.Context, line, skipReason string, fields logrus.Fields) {
+	logrus.WithFields(fields).WithField("line", line).Debugln("Skipped:", skipReason)
+
+	if ev := getEvent(ctx); ev != nil {
+		ev.AddField("log_line", line)
+		ev.AddField("skip_reason", skipReason)
+		ev.Send()
+	}
+}
+
+func SendError(ctx context.Context, sentEvent *event.Event, err error) {
+	logrus.WithFields(logrus.Fields{
+		"event": sentEvent,
+		"error": err,
+	}).Error("Unexpected error when sending to Honeycomb")
+
+	if ev := getEvent(ctx); ev != nil {
+		ev.AddField("event_timestamp", sentEvent.Timestamp)
+		ev.AddField("event_timestamp_lag_sec", time.Since(sentEvent.Timestamp)/time.Second)
+		ev.AddField("event_data", sentEvent.Data)
+		ev.AddField("honeycomb_error", err.Error())
+		ev.Send()
+	}
+}
+
+func Response(ctx context.Context, rsp *libhoney.Response, willRetry bool) {
+	logrus.WithFields(logrus.Fields{
+		"status_code": rsp.StatusCode,
+		"body":        strings.TrimSpace(string(rsp.Body)),
+		"duration":    rsp.Duration,
+		"error":       rsp.Err,
+	}).Debug("Server response")
+
+	if ev := getEvent(ctx); ev != nil {
+		defer func() {
+			// If we've called libhoney.Close(), response handling will still
+			// happen - and we should be fine with just tossing away telemetry
+			// as a result
+			recover()
+		}()
+
+		sentEvent := rsp.Metadata.(event.Event)
+		ev.AddField("event_timestamp", sentEvent.Timestamp)
+		ev.AddField("event_timestamp_lag_sec", time.Since(sentEvent.Timestamp)/time.Second)
+		ev.AddField("event_data", sentEvent.Data)
+		ev.AddField("response_status_code", rsp.StatusCode)
+		ev.AddField("response_latency_ms", rsp.Duration/time.Millisecond)
+		if rsp.StatusCode > 400 {
+			ev.AddField("honeycomb_error", rsp.Err.Error())
+		}
+		ev.Send()
+	}
+}
+
+func getEvent(ctx context.Context) *libhoney.Event {
+	builder, ok := ctx.Value(contextKeyBuilder).(*libhoney.Builder)
+	if !ok { // will bail if not configured to report
+		return nil
+	}
+
+	ev := builder.NewEvent()
+	ev.Dataset += reportingSuffix
+	return ev
+}

--- a/tail/tail.go
+++ b/tail/tail.go
@@ -81,7 +81,7 @@ func GetSampledEntries(ctx context.Context, conf Config, sampleRate uint) ([]cha
 					logrus.WithFields(logrus.Fields{
 						"line":       line,
 						"samplerate": sampleRate,
-					}).Debug("Sampler says skip this line")
+					}).Debug("Skipped: dropped line due to sampling")
 				} else {
 					sampledLines <- line
 				}


### PR DESCRIPTION
Influenced by #28, but is opt-in and richer than the summary stats proposed in that diff.

The goal is to allow folks to capture richer telemetry from honeytail on an opt-in basis, to a dataset within the same team. (Suffixed with `-reports`, and relies on the currently-default automatic-creation behavior.)

The existence of a `libhoney.Builder` (which in turns is determined by the presence of the `--report` flag) dictates whether a telemetry event gets sent, and we use dynamic sampling to keep those telemetry events under control.

This diff also does a pass to clean up and standardize existing `.Debug` lines that line up with `reporting.*` calls.