### PR TITLE
Fix race conditions in parser unit tests

### DIFF
--- a/parsers/keyval/keyval.go
+++ b/parsers/keyval/keyval.go
@@ -168,13 +168,3 @@ func allEmpty(pl map[string]interface{}) bool {
 	// we've gone through the entire map and every field value has matched ""
 	return true
 }
-
-type NoopLineParser struct {
-	incomingLine string
-	outgoingMap  map[string]interface{}
-}
-
-func (n *NoopLineParser) ParseLine(line string) (map[string]interface{}, error) {
-	n.incomingLine = line
-	return n.outgoingMap, nil
-}


### PR DESCRIPTION
Tests for the keyval parser were using a `NoopLineParser` that wasn't safe for
concurrent use. But it isn't really necessary in those tests, so just
initialize and use a normal `Parser` instead.

Note: this doesn't fix all the problems with the tests. The unit tests in
`tail_test.go` still have a data race, and the flaky tests we see in travis
probably aren't all fixed by this. But it's a start.