### PR TITLE
When consuming lines, only trim whitespace in parsers (fixes postgres)

### DIFF
--- a/parsers/arangodb/arangodb.go
+++ b/parsers/arangodb/arangodb.go
@@ -173,7 +173,7 @@ func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, pref
 		wg.Add(1)
 		go func() {
 			for line := range lines {
-
+				line = strings.TrimSpace(line)
 				// take care of any headers on the line
 				var prefixFields map[string]string
 				if prefixRegex != nil {

--- a/parsers/htjson/htjson.go
+++ b/parsers/htjson/htjson.go
@@ -53,6 +53,7 @@ func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, pref
 		wg.Add(1)
 		go func() {
 			for line := range lines {
+				line = strings.TrimSpace(line)
 				logrus.WithFields(logrus.Fields{
 					"line": line,
 				}).Debug("Attempting to process json log line")

--- a/parsers/keyval/keyval.go
+++ b/parsers/keyval/keyval.go
@@ -78,6 +78,7 @@ func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, pref
 		wg.Add(1)
 		go func() {
 			for line := range lines {
+				line = strings.TrimSpace(line)
 				logrus.WithFields(logrus.Fields{
 					"line": line,
 				}).Debug("Attempting to process keyval log line")

--- a/parsers/mongodb/mongodb.go
+++ b/parsers/mongodb/mongodb.go
@@ -83,6 +83,7 @@ func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, pref
 		wg.Add(1)
 		go func(pNum int) {
 			for line := range lines {
+				line = strings.TrimSpace(line)
 				// take care of any headers on the line
 				var prefixFields map[string]string
 				if prefixRegex != nil {

--- a/parsers/mysql/mysql.go
+++ b/parsers/mysql/mysql.go
@@ -320,6 +320,7 @@ func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, pref
 	var foundStatement bool
 	groupedLines := make([]string, 0, 5)
 	for line := range lines {
+		line = strings.TrimSpace(line)
 		// mysql parser does not support capturing fields in the line prefix - just
 		// strip it.
 		if prefixRegex != nil {

--- a/parsers/nginx/nginx.go
+++ b/parsers/nginx/nginx.go
@@ -79,6 +79,7 @@ func (n *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, pref
 		wg.Add(1)
 		go func() {
 			for line := range lines {
+				line = strings.TrimSpace(line)
 				logrus.WithFields(logrus.Fields{
 					"line": line,
 				}).Debug("Attempting to process nginx log line")

--- a/tail/tail.go
+++ b/tail/tail.go
@@ -204,7 +204,7 @@ func tailSingleFile(ctx context.Context, tailer *tail.Tail, file string, stateFi
 					// skip errored lines
 					continue
 				}
-				lines <- strings.TrimSpace(line.Text)
+				lines <- line.Text
 			case <-ctx.Done():
 				// will only trigger when the context is cancelled
 				break ReadLines


### PR DESCRIPTION
This is an issue that currently isn't caught by unit tests. In the postgres
parser, we rely on the existence of leading whitespace to distinguish lines
that are the continuation of a SQL statement, e.g.:

```
2017-11-07 01:43:39 UTC [3542-7] postgres@test LOG:  duration: 15.577 ms  statement: SELECT * FROM test
		WHERE id=1;
```

from lines that are a new statement.

But in `tail.go`, we were stripping leading and trailing whitespace. Do you
remember what the scenarios were that we needed that for? For the moment, I've
been conservative and lifted the `strings.TrimSpace` call into all the parsers
except the postgres one. Not sure if this is the best approach. It does mean
that this won't accidentally break anything.