### PR TITLE
Better/more helpful log output for honeytail

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -43,8 +43,8 @@
 		},
 		{
 			"ImportPath": "github.com/honeycombio/libhoney-go",
-			"Comment": "v1.4.0-2-g1782b3e",
-			"Rev": "1782b3ea9b57603d943377079c2c7151049b1448"
+			"Comment": "v1.3.2-9-g9bdca60",
+			"Rev": "9bdca6032bc1b4f0bcbd590f3dc71102b38106dd"
 		},
 		{
 			"ImportPath": "github.com/honeycombio/mongodbtools/logparser",

--- a/event/event.go
+++ b/event/event.go
@@ -18,3 +18,7 @@ type Event struct {
 	// metrics to submit in this event
 	Data map[string]interface{}
 }
+
+func (e *Event) LagSeconds() float64 {
+	return float64(time.Since(e.Timestamp)) / float64(time.Second)
+}

--- a/event/event.go
+++ b/event/event.go
@@ -19,6 +19,6 @@ type Event struct {
 	Data map[string]interface{}
 }
 
-func (e *Event) LagSeconds() time.Duration {
-	return time.Since(e.Timestamp) / time.Second
+func (e *Event) Lag() time.Duration {
+	return time.Since(e.Timestamp)
 }

--- a/event/event.go
+++ b/event/event.go
@@ -19,6 +19,6 @@ type Event struct {
 	Data map[string]interface{}
 }
 
-func (e *Event) LagSeconds() float64 {
-	return float64(time.Since(e.Timestamp)) / float64(time.Second)
+func (e *Event) LagSeconds() time.Duration {
+	return time.Since(e.Timestamp) / time.Second
 }

--- a/leash.go
+++ b/leash.go
@@ -545,10 +545,12 @@ func outputHelp(options GlobalOptions, stats *responseStats, teamSlug string) {
 		}
 	}
 
-	if !options.Backfill && stats.finalAvgLagSeconds > reporting.AvgLagThreshold {
-		logrus.Warn("Psst -- it looks like you transmitted a lot of events with old timestamps!")
-		logrus.Warnf("(The average was around %.2f seconds)", stats.finalAvgLagSeconds)
-		logrus.Warn("Sometimes this happens when honeytail isn't able to keep up with the input stream.\n")
+	// Check the average lag for the last interval. If it's over the
+	// AvgLagThreshold, warn the user.
+	if !options.Backfill && stats.cumulAvgLag > reporting.AvgLagThreshold {
+		logrus.Warn("Psst -- looks like you transmitted a lot of events with old timestamps!")
+		logrus.Warn("  (The average was around ", stats.cumulAvgLag, ")")
+		logrus.Warn("If you didn't mean to send events timestamped over ", reporting.AvgLagThreshold, " ago, this process may be failing to keep up with the input stream.\n")
 	}
 
 	// Nothing bad happened, yay

--- a/leash.go
+++ b/leash.go
@@ -545,7 +545,7 @@ func outputHelp(options GlobalOptions, stats *responseStats, teamSlug string) {
 		}
 	}
 
-	if !options.Backfill && stats.finalAvgLagSeconds > 60*60 {
+	if !options.Backfill && stats.finalAvgLagSeconds > reporting.AvgLagThreshold {
 		logrus.Warn("Psst -- it looks like you transmitted a lot of events with old timestamps!")
 		logrus.Warnf("(The average was around %.2f seconds)", stats.finalAvgLagSeconds)
 		logrus.Warn("Sometimes this happens when honeytail isn't able to keep up with the input stream.\n")

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
@@ -172,14 +173,16 @@ func main() {
 	addParserDefaultOptions(&options)
 	sanityCheckOptions(&options)
 
-	if err := libhoney.VerifyWriteKey(libhoney.Config{
+	teamSlug, err := libhoney.VerifyWriteKey(libhoney.Config{
 		APIHost:  options.APIHost,
 		WriteKey: options.Reqs.WriteKey,
-	}); err != nil {
+	})
+
+	if err != nil {
 		fmt.Fprintln(os.Stderr, "Could not verify Honeycomb write key: ", err)
 		os.Exit(1)
 	}
-	run(options)
+	run(options, teamSlug)
 }
 
 // setVersion sets the internal version ID and updates libhoney's user-agent

--- a/reporting/reporting.go
+++ b/reporting/reporting.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	Suffix          = "-reports"
-	AvgLagThreshold = 60 * 60 * time.Second
+	AvgLagThreshold = 30 * 60 * time.Second
 
 	contextKeyBuilder = "builder"
 	contextKeySampler = "sampler"
@@ -97,7 +97,7 @@ func SendError(ctx context.Context, sentEvent *event.Event, err error) {
 
 	if ev := getEvent(ctx, "send error"); ev != nil {
 		ev.AddField("event_timestamp", sentEvent.Timestamp)
-		ev.AddField("event_timestamp_lag_sec", sentEvent.LagSeconds())
+		ev.AddField("event_timestamp_lag_sec", sentEvent.Lag()/time.Second)
 		ev.AddField("event_data", sentEvent.Data)
 		ev.AddField("honeycomb_error", err.Error())
 		ev.Send()
@@ -122,7 +122,7 @@ func Response(ctx context.Context, rsp *libhoney.Response, willRetry bool) {
 
 		sentEvent := rsp.Metadata.(event.Event)
 		ev.AddField("event_timestamp", sentEvent.Timestamp)
-		ev.AddField("event_timestamp_lag_sec", sentEvent.LagSeconds())
+		ev.AddField("event_timestamp_lag_sec", sentEvent.Lag()/time.Second)
 		ev.AddField("event_data", sentEvent.Data)
 		ev.AddField("response_status_code", rsp.StatusCode)
 		ev.AddField("response_latency_ms", rsp.Duration/time.Millisecond)

--- a/reporting/reporting.go
+++ b/reporting/reporting.go
@@ -95,7 +95,7 @@ func SendError(ctx context.Context, sentEvent *event.Event, err error) {
 
 	if ev := getEvent(ctx, "send error"); ev != nil {
 		ev.AddField("event_timestamp", sentEvent.Timestamp)
-		ev.AddField("event_timestamp_lag_sec", time.Since(sentEvent.Timestamp)/time.Second)
+		ev.AddField("event_timestamp_lag_sec", sentEvent.LagSeconds())
 		ev.AddField("event_data", sentEvent.Data)
 		ev.AddField("honeycomb_error", err.Error())
 		ev.Send()
@@ -120,7 +120,7 @@ func Response(ctx context.Context, rsp *libhoney.Response, willRetry bool) {
 
 		sentEvent := rsp.Metadata.(event.Event)
 		ev.AddField("event_timestamp", sentEvent.Timestamp)
-		ev.AddField("event_timestamp_lag_sec", time.Since(sentEvent.Timestamp)/time.Second)
+		ev.AddField("event_timestamp_lag_sec", sentEvent.LagSeconds())
 		ev.AddField("event_data", sentEvent.Data)
 		ev.AddField("response_status_code", rsp.StatusCode)
 		ev.AddField("response_latency_ms", rsp.Duration/time.Millisecond)

--- a/reporting/reporting.go
+++ b/reporting/reporting.go
@@ -14,9 +14,11 @@ import (
 )
 
 const (
+	Suffix          = "-reports"
+	AvgLagThreshold = 60 * 60 * time.Second
+
 	contextKeyBuilder = "builder"
 	contextKeySampler = "sampler"
-	Suffix            = "-reports"
 )
 
 // NewContext returns a context with a builder attached. This enables any

--- a/reporting/reporting.go
+++ b/reporting/reporting.go
@@ -16,12 +16,14 @@ import (
 const (
 	contextKeyBuilder = "builder"
 	contextKeySampler = "sampler"
-	reportingSuffix   = "-reports"
+	Suffix            = "-reports"
 )
 
+// NewContext returns a context with a builder attached. This enables any
+// successive reporting.* fns to send to Honeycomb
 func NewContext(ctx context.Context) context.Context {
 	builder := libhoney.NewBuilder()
-	builder.Dataset += reportingSuffix
+	builder.Dataset += Suffix
 	if hostname, err := os.Hostname(); err == nil {
 		builder.AddField("hostname", hostname)
 	}
@@ -38,6 +40,8 @@ func NewContext(ctx context.Context) context.Context {
 	return context.WithValue(ctx, contextKeySampler, sampler)
 }
 
+// Options sends a Honeycomb event containing the Options received by the
+// honeytail binary.
 func Options(ctx context.Context, options interface{}) {
 	if ev := getEvent(ctx, "options"); ev != nil {
 		ev.AddField("config_json", options)

--- a/response_stats.go
+++ b/response_stats.go
@@ -101,17 +101,24 @@ func (r *responseStats) log() {
 }
 
 // log the total count on its own
-func (r *responseStats) logFinal() {
+func (r *responseStats) logFinal() (int, int) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	r.totalCount += r.count
+	successes := 0
 	for code, count := range r.statusCodes {
 		r.totalStatusCodes[code] += count
+		if code >= 200 && code < 300 {
+			successes += r.totalStatusCodes[code]
+		}
 	}
 	logrus.WithFields(logrus.Fields{
-		"total attempted sends":               r.totalCount,
-		"number sent by response status code": r.totalStatusCodes,
+		"total attempted sends":                   r.totalCount,
+		"total successful sends":                  successes,
+		"ultimate # of responses, by status code": r.totalStatusCodes,
 	}).Info("Total number of events sent")
+
+	return r.totalCount, successes
 }
 
 // reset the counters to zero.

--- a/response_stats.go
+++ b/response_stats.go
@@ -30,7 +30,7 @@ type responseStats struct {
 
 	totalCount         int
 	totalStatusCodes   map[int]int
-	finalAvgLagSeconds float64 // cumulative moving avg
+	finalAvgLagSeconds time.Duration // cumulative moving avg
 }
 
 // newResponseStats initializes the struct's complex data types
@@ -66,7 +66,7 @@ func (r *responseStats) update(rsp libhoney.Response) {
 	r.sumDuration += rsp.Duration
 	ev := rsp.Metadata.(event.Event)
 	r.event = &ev
-	r.finalAvgLagSeconds += (ev.LagSeconds() - r.finalAvgLagSeconds) / float64(r.totalCount)
+	r.finalAvgLagSeconds += (ev.LagSeconds() - r.finalAvgLagSeconds) / time.Duration(r.totalCount)
 }
 
 // log the current stats and reset them all to zero.

--- a/response_stats.go
+++ b/response_stats.go
@@ -27,10 +27,11 @@ type responseStats struct {
 	sumDuration time.Duration
 	minDuration time.Duration
 	event       *event.Event
+	cumulAvgLag time.Duration // cumulative moving avg
 
-	totalCount         int
-	totalStatusCodes   map[int]int
-	finalAvgLagSeconds time.Duration // cumulative moving avg
+	totalCount        int
+	totalStatusCodes  map[int]int
+	lastAvgLagSeconds time.Duration
 }
 
 // newResponseStats initializes the struct's complex data types
@@ -66,7 +67,7 @@ func (r *responseStats) update(rsp libhoney.Response) {
 	r.sumDuration += rsp.Duration
 	ev := rsp.Metadata.(event.Event)
 	r.event = &ev
-	r.finalAvgLagSeconds += (ev.LagSeconds() - r.finalAvgLagSeconds) / time.Duration(r.totalCount)
+	r.cumulAvgLag += (ev.Lag() - r.cumulAvgLag) / time.Duration(r.count)
 }
 
 // log the current stats and reset them all to zero.


### PR DESCRIPTION
Some surprisingly complicated logic around outputting helper text at the end of `honeytail` execution. Open to all manner of feedback, from general concerns about the cues we use to trigger text to the specific wording / thresholds.

Specifically open to:
- Field names used for the `--report` dataset. We can guide folks a bit, but as much as possible I'd like to minimize the "... what does lag_msec mean?" when folks are already probably using `--report` because `honeytail` did something funny
- (Feels super trivial, but) the whitespace in terminal output. It looks super awkward right now and thoughts on cleaning that up would be **super** appreciated)

Looking for review from:
- @maplebed for honeytail logic/structure munging
- @nathanleclaire for cases that would've been helpful to cover in the past, based on customers you've helped with honeytail/honeyelb/etc
- @piebob for language 🙏  (tried to keep the logic straightforward-ish so you can figure out how the text reads, lmk if you 

---

Currently, for a successful backfill:

![image](https://user-images.githubusercontent.com/188595/32685920-854e4186-c650-11e7-85ee-75bfc7bb1a36.png)

And that successful backfill with `--report` provided:

![image](https://user-images.githubusercontent.com/188595/32685924-93450ef0-c650-11e7-97d9-b8b413a2622b.png)

Operating on a malformed file (and sending no data):

![image](https://user-images.githubusercontent.com/188595/32685955-d281c4b4-c650-11e7-8607-30d3f70cd04d.png)

And that malformed file (with no sends) and `--report` provided:

![image](https://user-images.githubusercontent.com/188595/32685961-e3023fe4-c650-11e7-81e6-4c9cc4d9ff48.png)

And a non-[`--backfill`](https://honeycomb.io/docs/connect/agent/#backfilling-existing-data) honeytail invocation, which processes some events successfully (but notices that the events sent typically lag by more than an hour):

![image](https://user-images.githubusercontent.com/188595/32685986-685dd086-c651-11e7-90a7-794cb624a132.png)