### PR TITLE
Make parsing robust to setting NumParsers=0

### DIFF
--- a/parsers/htjson/htjson.go
+++ b/parsers/htjson/htjson.go
@@ -49,7 +49,11 @@ func (j *JSONLineParser) ParseLine(line string) (map[string]interface{}, error) 
 
 func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, prefixRegex *parsers.ExtRegexp) {
 	wg := sync.WaitGroup{}
-	for i := 0; i < p.conf.NumParsers; i++ {
+	numParsers := 1
+	if p.conf.NumParsers > 0 {
+		numParsers = p.conf.NumParsers
+	}
+	for i := 0; i < numParsers; i++ {
 		wg.Add(1)
 		go func() {
 			for line := range lines {

--- a/parsers/keyval/keyval.go
+++ b/parsers/keyval/keyval.go
@@ -74,7 +74,11 @@ func (j *KeyValLineParser) ParseLine(line string) (map[string]interface{}, error
 
 func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, prefixRegex *parsers.ExtRegexp) {
 	wg := sync.WaitGroup{}
-	for i := 0; i < p.conf.NumParsers; i++ {
+	numParsers := 1
+	if p.conf.NumParsers > 0 {
+		numParsers = p.conf.NumParsers
+	}
+	for i := 0; i < numParsers; i++ {
 		wg.Add(1)
 		go func() {
 			for line := range lines {

--- a/parsers/mongodb/mongodb_test.go
+++ b/parsers/mongodb/mongodb_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/honeycombio/honeytail/event"
 	"github.com/honeycombio/honeytail/httime"
 	"github.com/honeycombio/honeytail/httime/httimetest"
-	"github.com/honeycombio/honeytail/parsers"
 )
 
 const (
@@ -420,10 +419,6 @@ func TestProcessLines(t *testing.T) {
 		conf: Options{
 			NumParsers: 5,
 		},
-	}
-	m.lineParsers = make([]parsers.LineParser, m.conf.NumParsers)
-	for i := 0; i < m.conf.NumParsers; i++ {
-		m.lineParsers[i] = &MongoLineParser{}
 	}
 	lines := make(chan string)
 	send := make(chan event.Event)

--- a/parsers/regex/regex.go
+++ b/parsers/regex/regex.go
@@ -145,7 +145,11 @@ func (p *RegexLineParser) ParseLine(line string) (map[string]interface{}, error)
 func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, prefixRegex *parsers.ExtRegexp) {
 	// parse lines one by one
 	wg := sync.WaitGroup{}
-	for i := 0; i < p.conf.NumParsers; i++ {
+	numParsers := 1
+	if p.conf.NumParsers > 0 {
+		numParsers = p.conf.NumParsers
+	}
+	for i := 0; i < numParsers; i++ {
 		wg.Add(1)
 		go func() {
 			for line := range lines {


### PR DESCRIPTION
Currently, if you configure rdslogs to send events directly to Honeycomb, it
will instantiate a MySQL parser, but not set `NumParsers` to a positive value.
So that causes rdslogs to simply hang.

As a general matter of good practice, we might as well make it so that these
parsers work even if `NumParsers` isn't set. Do that in this patch.