### PR TITLE
Parse prepared statements in postgres logs

### DIFF
--- a/parsers/postgresql/postgresql.go
+++ b/parsers/postgresql/postgresql.go
@@ -68,7 +68,7 @@ const (
 	timestampRe   = `\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[.0-9]* [A-Z]+`
 	defaultPrefix = "%t [%p-%l] %u@%d"
 	// Regex string that matches the header of a slow query log line
-	slowQueryHeader = `\s*(?P<level>[A-Z0-9]+):\s+duration: (?P<duration>[0-9\.]+) ms\s+statement: `
+	slowQueryHeader = `\s*(?P<level>[A-Z0-9]+):\s+duration: (?P<duration>[0-9\.]+) ms\s+(?:(statement)|(execute \S+)): `
 )
 
 var slowQueryHeaderRegex = &parsers.ExtRegexp{regexp.MustCompile(slowQueryHeader)}

--- a/parsers/postgresql/postgresql_test.go
+++ b/parsers/postgresql/postgresql_test.go
@@ -81,6 +81,23 @@ func TestSingleQueryParsing(t *testing.T) {
 				},
 			},
 		},
+		{
+			description:  "parse a prepared statement",
+			in:           `2017-11-07 23:05:16 UTC [3053-3] postgres@postgres LOG:  duration: 0.681 ms  execute sbstmt-1751784287-397260381: SELECT c FROM sbtest1 WHERE id=$1`,
+			prefixFormat: "%t [%p-%l] %u@%d",
+			expected: event.Event{
+				Timestamp: time.Date(2017, 11, 7, 23, 5, 16, 0, time.UTC),
+				Data: map[string]interface{}{
+					"user":     "postgres",
+					"database": "postgres",
+					"duration": 0.681,
+					"pid":      3053,
+					"session_line_number": 3,
+					"query":               "SELECT c FROM sbtest1 WHERE id=$1",
+					"normalized_query":    "select c from sbtest1 where id=$?",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
PostgreSQL prepared statements (i.e., statements with bind parameters
rather than inline parameters) look like this in the logs:

```
2017-12-22 22:14:10 UTC:10.2.31.141(51017):honeycomb@sbtest:[2035]:LOG:  duration: 0.065 ms  bind sbstmt-513671205-1941546510: SELECT c FROM sbtest1 WHERE id BETWEEN $1 AND $2 ORDER BY c
2017-12-22 22:14:10 UTC:10.2.31.141(51017):honeycomb@sbtest:[2035]:DETAIL:  parameters: $1 = '5043', $2 = '5142'
2017-12-22 22:14:10 UTC:10.2.31.141(51017):honeycomb@sbtest:[2035]:LOG:  duration: 0.218 ms  execute sbstmt-513671205-1941546510: SELECT c FROM sbtest1 WHERE id BETWEEN $1 AND $2 ORDER BY c
```

So there are three log lines for each query: "bind", "parameters" and
"execute". Currently, we fail to parse these at all. As an interim
measure, just parse the "execute" line. It would be nice to parse the
parameters as well, but that would require more logic to glue the lines
together. (People often don't want to send the raw parameters anyways,
out of concern for sensitive data.)