### PR TITLE
Improve user-facing error message for nginx options

### DIFF
--- a/leash.go
+++ b/leash.go
@@ -123,8 +123,8 @@ func run(options GlobalOptions) {
 
 		// and initialize it
 		if err := parser.Init(opts); err != nil {
-			logrus.WithFields(logrus.Fields{"parser": options.Reqs.ParserName, "err": err}).Fatal(
-				"err initializing parser module")
+			logrus.Fatalf(
+				"Error initializing %s parser module: %v", options.Reqs.ParserName, err)
 		}
 
 		// create a channel for sending events into libhoney

--- a/parsers/nginx/nginx.go
+++ b/parsers/nginx/nginx.go
@@ -2,6 +2,8 @@
 package nginx
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -38,10 +40,14 @@ type Parser struct {
 func (n *Parser) Init(options interface{}) error {
 	n.conf = *options.(*Options)
 
+	if n.conf.ConfigFile == "" {
+		return errors.New("missing required option --nginx.conf=<path to your Nginx config file>")
+	}
+
 	// Verify we've got our config, find our format
-	nginxConfig, err := os.Open(string(n.conf.ConfigFile))
+	nginxConfig, err := os.Open(n.conf.ConfigFile)
 	if err != nil {
-		return err
+		return fmt.Errorf("couldn't open Nginx config file %s: %v", n.conf.ConfigFile, err)
 	}
 	defer nginxConfig.Close()
 	// get the nginx log format from the config file


### PR DESCRIPTION
Previously if you tried to run honeytail with `--parser=nginx` but
without the `--nginx.conf` argument, you'd get:
```
$ honeytail -k $WRITEKEY --dataset="nginx API logs" --parser=nginx --file=test.log
INFO[0000] Starting honeytail
FATA[0000] err initializing parser module                err=open : no such file or directory parser=nginx
```

Hopelessly confusing.

Now, you'll get:
```
$ honeytail -k $WRITEKEY --dataset="nginx API logs" --parser=nginx --file=test.log
INFO[0000] Starting honeytail
FATA[0000] Error initializing nginx parser module: missing required option --nginx.conf=<path to your Nginx config file>
```

which at least somewhat clearer.