### PR TITLE
add reference of keyval/logfmt parser to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Our complete list of parsers can be found in the [`parsers/` directory](parsers/
 - [PostgreSQL](parsers/postgresql/)
 - [nginx](parsers/nginx/)
 - [regex](parsers/regex/)
+- [keyval](parsers/keyval/) ([logfmt](https://brandur.org/logfmt))
 
 ## Installation
 


### PR DESCRIPTION
We were super psyched to learn that honeytail supports our logfmt logs out of the box, and would like to make this information easier to find.

Honeytail is bringing us a lot of joy! 💜