### PR TITLE
parsers/postgresql: ensure prefix matching actually matches the beginning of the string

### DIFF
--- a/parsers/postgresql/postgresql.go
+++ b/parsers/postgresql/postgresql.go
@@ -285,6 +285,7 @@ func buildPrefixRegexp(prefixFormat string) (*parsers.ExtRegexp, error) {
 	for k, v := range prefixValues {
 		prefixFormat = strings.Replace(prefixFormat, k, v.ReString(), -1)
 	}
+	prefixFormat = "^" + prefixFormat
 
 	re, err := regexp.Compile(prefixFormat)
 	if err != nil {

--- a/parsers/postgresql/postgresql_test.go
+++ b/parsers/postgresql/postgresql_test.go
@@ -226,7 +226,6 @@ func TestEnsureRegexMatchesBeginningOfLine(t *testing.T) {
 func TestCustomLogLinePrefix(t *testing.T) {
 	parser := Parser{}
 	parser.Init(&Options{
-		// missing "[PUCE] " prefix
 		LogLinePrefix: "[PUCE] [%p-%l]  sql_error_code = %e",
 	})
 	line := "[PUCE] [200-1]  sql_error_code = 00000 LOG:  duration: 1050.729 ms  execute <unnamed>: UPDATE \"repositories\" SET \"current_build_id\" = 341933279, \"updated_at\" = '2018-02-15 15:21:55.174858' WHERE \"repositories\".\"id\" = 16235973"


### PR DESCRIPTION
ran into this while trying to consume heroku postgres logs with honeytail.

this matching causes issues in `parsePrefix`, because it assumes the match starts at the beginning of the line. so when it doesn't, the substring slicing may end up not stripping the whole prefix, causing issues with the rest of the parsing down the line.