### PR TITLE
use uint32 rather than big.Int in DeterministicSampler

### DIFF
--- a/sample/deterministic_sampler.go
+++ b/sample/deterministic_sampler.go
@@ -3,23 +3,14 @@ package sample
 import (
 	"crypto/sha1"
 	"errors"
-	"math/big"
+	"math"
 )
 
 var (
 	ErrInvalidSampleRate = errors.New("sample rate must be >= 1")
-	maxVal               = new(big.Int)
 )
 
 func init() {
-	// maximum possible value for the field value is 160 bytes long
-	// (sha1.Size is 20)
-	maxVal.Exp(
-		big.NewInt(2),
-		big.NewInt(int64(sha1.Size*8)),
-		big.NewInt(0),
-	)
-	maxVal.Sub(maxVal, big.NewInt(1))
 }
 
 // DeterministicSampler allows for distributed sampling based on a common field
@@ -29,33 +20,32 @@ func init() {
 // communication.
 type DeterministicSampler struct {
 	sampleRate int
-	upperBound *big.Int
+	upperBound uint32
 }
 
 func NewDeterministicSampler(sampleRate uint) (*DeterministicSampler, error) {
 	if sampleRate < 1 {
 		return nil, ErrInvalidSampleRate
 	}
-	upperBound := new(big.Int)
 
 	// Get the actual upper bound - the largest possible value divided by
 	// the sample rate. In the case where the sample rate is 1, this should
 	// sample every value.
-	upperBound.Div(maxVal, big.NewInt(int64(sampleRate)))
+	upperBound := math.MaxUint32 / uint32(sampleRate)
 	return &DeterministicSampler{
 		sampleRate: int(sampleRate),
 		upperBound: upperBound,
 	}, nil
 }
 
+// bytesToUint32 takes a slice of 4 bytes representing a big endian 32 bit
+// unsigned value and returns the equivalent uint32.
+func bytesToUint32be(b []byte) uint32 {
+	return uint32(b[3]) | (uint32(b[2]) << 8) | (uint32(b[1]) << 16) | (uint32(b[0]) << 24)
+}
+
 func (ds *DeterministicSampler) Sample(determinant string) bool {
 	sum := sha1.Sum([]byte(determinant))
-	determinantInt := new(big.Int)
-	determinantInt.SetBytes(sum[:])
-	cmp := determinantInt.Cmp(ds.upperBound)
-	if cmp <= 0 {
-		return true
-	}
-
-	return false
+	v := bytesToUint32be(sum[:4])
+	return v <= ds.upperBound
 }

--- a/sample/deterministic_sampler_test.go
+++ b/sample/deterministic_sampler_test.go
@@ -32,6 +32,24 @@ func randomRequestID() string {
 	return reqID
 }
 
+func assertEqual(t *testing.T, a interface{}, b interface{}) {
+	if a != b {
+		t.Fatalf("%v != %v", a, b)
+	}
+}
+
+func TestDeterministicSamplerDatapoints(t *testing.T) {
+	s, _ := NewDeterministicSampler(17)
+	a := s.Sample("hello")
+	assertEqual(t, a, false)
+	a = s.Sample("hello")
+	assertEqual(t, a, false)
+	a = s.Sample("world")
+	assertEqual(t, a, false)
+	a = s.Sample("this5")
+	assertEqual(t, a, true)
+}
+
 func TestDeterministicSampler(t *testing.T) {
 	const (
 		nRequestIDs             = 200000


### PR DESCRIPTION
Since sample rates range from 1 up to around a million (in the most extreme case), we can avoid some allocations by just considering the first 32 bits of the hash.

Also add a known answer test to confirm that this doesn't change the behavior (the test passes before and after the big.Int -> uint32 change).