### PR TITLE
Add --rebase_time argument

### DIFF
--- a/leash_test.go
+++ b/leash_test.go
@@ -670,14 +670,14 @@ func TestGetEndLine(t *testing.T) {
 }
 
 func TestRebaseTime(t *testing.T) {
-	baseTime, err := time.Parse("Mon Jan 2 15:04:05 -0700 MST 2006", "Wed Jul 3 15:04:05 -0800 PST 2018")
+	baseTime, err := time.Parse("Mon Jan 2 15:04:05 -0700 MST 2006", "Wed Jul 3 15:04:05 -0700 PDT 2018")
 	assert.Nil(t, err)
-	nowTime, err := time.Parse("Mon Jan 2 15:04:05 -0700 MST 2006", "Wed Jul 4 12:00:00 -0800 PST 2018")
+	nowTime, err := time.Parse("Mon Jan 2 15:04:05 -0700 MST 2006", "Wed Jul 4 12:00:00 -0700 PDT 2018")
 	assert.Nil(t, err)
-	timestamp, err := time.Parse("Mon Jan 2 15:04:05 -0700 MST 2006", "Wed Jul 3 12:00:05 -0800 PST 2018")
+	timestamp, err := time.Parse("Mon Jan 2 15:04:05 -0700 MST 2006", "Wed Jul 3 12:00:05 -0700 PDT 2018")
 	assert.Nil(t, err)
 	// should be three hours, four minutes behind our nowTime
-	expected, err := time.Parse("Mon Jan 2 15:04:05 -0700 MST 2006", "Wed Jul 4 08:56:00 -0800 PST 2018")
+	expected, err := time.Parse("Mon Jan 2 15:04:05 -0700 MST 2006", "Wed Jul 4 08:56:00 -0700 PDT 2018")
 	assert.Nil(t, err)
 	rebasedTime := rebaseTime(baseTime, nowTime, timestamp)
 	assert.Equal(t, expected, rebasedTime)
@@ -685,10 +685,10 @@ func TestRebaseTime(t *testing.T) {
 
 func TestGetBaseTime(t *testing.T) {
 	fileContents := `
-{"key1": "value1", "timestamp": "Wed Jul 3 12:00:05 -0800 PST 2018"}
-{"key1": "value2", "timestamp": "Wed Jul 3 13:00:05 -0800 PST 2018"}
-{"key1": "value3", "timestamp": "Wed Jul 3 14:00:05 -0800 PST 2018"}
-{"key1": "value4", "timestamp": "Wed Jul 3 15:04:05 -0800 PST 2018"}
+{"key1": "value1", "timestamp": "Wed Jul 3 12:00:05 -0700 PDT 2018"}
+{"key1": "value2", "timestamp": "Wed Jul 3 13:00:05 -0700 PDT 2018"}
+{"key1": "value3", "timestamp": "Wed Jul 3 14:00:05 -0700 PDT 2018"}
+{"key1": "value4", "timestamp": "Wed Jul 3 15:04:05 -0700 PDT 2018"}
 `
 
 	f, err := ioutil.TempFile(os.TempDir(), "honeytail-test")
@@ -709,9 +709,9 @@ func TestGetBaseTime(t *testing.T) {
 		},
 	}
 
-	expected, err := time.Parse("Mon Jan 2 15:04:05 -0700 MST 2006", "Wed Jul 3 15:04:05 -0800 PST 2018")
+	expected, err := time.Parse("Mon Jan 2 15:04:05 -0700 MST 2006", "Wed Jul 3 15:04:05 -0700 PDT 2018")
 	assert.Nil(t, err)
 	baseTime, err := getBaseTime(options)
 	assert.Nil(t, err)
-	assert.Equal(t, expected, baseTime)
+	assert.Equal(t, expected.UTC(), baseTime.UTC())
 }

--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ type GlobalOptions struct {
 	DebugOut         bool `long:"debug_stdout" description:"Instead of sending events to Honeycomb, print them to STDOUT for debugging"`
 	StatusInterval   uint `long:"status_interval" description:"How frequently, in seconds, to print out summary info" default:"60"`
 	Backfill         bool `long:"backfill" description:"Configure honeytail to ingest old data in order to backfill Honeycomb. Sets the correct values for --backoff, --tail.read_from, and --tail.stop"`
+	RebaseTime       bool `long:"rebase_time" description:"When backfilling data, rebase timestamps relative to the current time."`
 
 	Localtime           bool     `long:"localtime" description:"When parsing a timestamp that has no time zone, assume it is in the same timezone as localhost instead of UTC (the default)"`
 	Timezone            string   `long:"timezone" description:"When parsing a timestamp use this time zone instead of UTC (the default). Must be specified in TZ format as seen here: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones"`


### PR DESCRIPTION
When set, timestamps are "rebased" onto the current time. The last event (chronologically) in the log file(s) is set to the current time. Event timestamps before this are updated relative to this time, with the time delta preserved.

For example, if now is Wed Jul 4 12:00:00 -0800 PST 2018, and the events start and end at Wed Jul 3 15:04:05 -0800 PST 2018 and Wed Jul 3 12:00:05 -0800 PST 2018, respectively, the events will be updated so that they appear to have started and ended at Wed Jul 4 08:56:00 -0800 PST 2018 and Wed Jul 4 12:00:00 -0800 PST 2018.

The goal is to allow you to input old data but look at it as though it happened recently.