### PR TITLE
Bump Go version and enable OSX builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,10 @@ script:
 # Build binary and packages
     - go install -ldflags "-X main.BuildID=1.${TRAVIS_BUILD_NUMBER}" github.com/honeycombio/honeytail/...
     - $GOPATH/bin/honeytail --write_default_config > ./honeytail.conf
-    - ./build-pkg.sh -v "1.${TRAVIS_BUILD_NUMBER}" -t deb
-    - ./build-pkg.sh -v "1.${TRAVIS_BUILD_NUMBER}" -t rpm
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./build-pkg.sh -v "1.${TRAVIS_BUILD_NUMBER}" -t deb; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./build-pkg.sh -v "1.${TRAVIS_BUILD_NUMBER}" -t rpm; fi
 # Check that packages install
-    - pkg-test/test.sh "1.${TRAVIS_BUILD_NUMBER}"
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pkg-test/test.sh "1.${TRAVIS_BUILD_NUMBER}"; fi
 
 before_install:
     # Install fpm for deb/rpm package building

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 os:
   - linux
+  - osx
 
 language: go
 
@@ -12,7 +13,7 @@ addons:
 dist: trusty
 
 go:
-    - 1.8
+    - "1.10"
 
 script:
     - set -e
@@ -28,9 +29,9 @@ script:
 
 before_install:
     # Install fpm for deb/rpm package building
-    - sudo apt-get -qq update
-    - sudo apt-get install -y build-essential rpm
-    - gem install fpm
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y build-essential rpm; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then gem install fpm; fi
 
 install:
         - true # HACK: fixes travis-CI lack of support for vendor/ + godeps


### PR DESCRIPTION
Since we will have the sample JSON file as part of the Gatekeeper tour I think we will want to revisit this.

I kind of wish we could get a Windows build together as well...