### PR TITLE
[time] change logic for handling fractional epoch time to deal with fractional precision

### DIFF
--- a/httime/httime.go
+++ b/httime/httime.go
@@ -13,6 +13,7 @@ const (
 	StrftimeChar        = "%"
 	UnixTimestampFmt    = "%s(%L)?"
 	UnixTimestampFmtAlt = "%s(.%L)?"
+	UnixTimestampFmtTxt = "unixepoch"
 )
 
 // TODO UnixTimestampFmt is not a regex - it shouldn't look like one. Also even
@@ -187,7 +188,9 @@ func tryTimeFormats(t, intendedFormat string) time.Time {
 	// hack it by just replacing all commas with periods and hope it works out.
 	// https://github.com/golang/go/issues/6189
 	t = strings.Replace(t, ",", ".", -1)
-	if (intendedFormat == UnixTimestampFmt) || (intendedFormat == UnixTimestampFmtAlt) {
+	if (intendedFormat == UnixTimestampFmt) ||
+		(intendedFormat == UnixTimestampFmtAlt) ||
+		(intendedFormat == UnixTimestampFmtTxt) {
 		if unix, err := strconv.ParseInt(t, 0, 64); err == nil {
 			return time.Unix(unix, 0)
 		}

--- a/httime/httime_test.go
+++ b/httime/httime_test.go
@@ -153,7 +153,7 @@ var tts = []testTimestamp{
 		diffThreshold: time.Millisecond,
 	},
 	{
-		format:        UnixTimestampFmt,
+		format:        UnixTimestampFmtAlt,
 		fieldName:     "time",
 		input:         "1440116565.123456",
 		tz:            utc,
@@ -161,7 +161,7 @@ var tts = []testTimestamp{
 		diffThreshold: time.Microsecond,
 	},
 	{
-		format:        UnixTimestampFmt,
+		format:        UnixTimestampFmtTxt,
 		fieldName:     "time",
 		input:         "1440116565.12345678",
 		tz:            utc,


### PR DESCRIPTION
Neither go nor strftime deal with times like 1532024683.0938044 (representing Thursday, July 19, 2018 6:24:43 PM and some fractional second). But this code isn't really doing strftime, it's trying to detect whether it's a unix time first. Also, there's no reason to pin it to exactly 3 allowed digits after the second when we should reasonably accept any fraction, regardless of precision.