### PR TITLE
Add option to unescape JSON fields encoded as strings

### DIFF
--- a/leash.go
+++ b/leash.go
@@ -422,6 +422,24 @@ func modifyEventContents(toBeSent chan event.Event, options GlobalOptions) chan 
 					if options.RebaseTime {
 						ev.Timestamp = rebaseTime(baseTime, startTime, ev.Timestamp)
 					}
+					if len(options.JSONFields) > 0 {
+						for _, field := range options.JSONFields {
+							jsonVal, ok := ev.Data[field].(string)
+							if !ok {
+								logrus.WithField("field", field).
+									Warn("Error asserting given field as string")
+								continue
+							}
+							var jsonMap map[string]interface{}
+							if err := json.Unmarshal([]byte(jsonVal), &jsonMap); err != nil {
+								logrus.WithField("field", field).
+									Warn("Error unmarshalling field as JSON")
+								continue
+							}
+
+							ev.Data[field] = jsonMap
+						}
+					}
 					newSent <- ev
 				}
 				wg.Done()

--- a/main.go
+++ b/main.go
@@ -83,6 +83,7 @@ type GlobalOptions struct {
 	PreSampledField     string   `long:"presampled" description:"If this log has already been sampled, specify the field containing the sample rate here and it will be passed along unchanged"`
 	GoalSampleRate      int      `hidden:"true" description:"used to hold the desired sample rate and set tailing sample rate to 1"`
 	MinSampleRate       int      `long:"dynsample_minimum" description:"if the rate of traffic falls below this, dynsampler won't sample" default:"1"`
+	JSONFields          []string `long:"json_field" description:"JSON fields encoded as string to unescape and properly parse before sending"`
 
 	Reqs  RequiredOptions `group:"Required Options"`
 	Modes OtherModes      `group:"Other Modes"`


### PR DESCRIPTION
This will allow JSON data stored as a string in files to be parsed as a proper object by Honeytail and send as non-escaped JSON to the API.