### PR TITLE
Add support for other timestamp types

### DIFF
--- a/httime/httime_test.go
+++ b/httime/httime_test.go
@@ -176,6 +176,14 @@ var tts = []testTimestamp{
 		expected:      time.Unix(1397113200, 0),
 		diffThreshold: 0,
 	},
+	{
+		format:        "",
+		input:         "1538860697500",
+		tz:            utc,
+		fieldName:     "timestamp",
+		expected:      time.Unix(1538860697, 500000000),
+		diffThreshold: 0,
+	},
 }
 
 func TestGetTimestampValid(t *testing.T) {


### PR DESCRIPTION
This will allow Honeytail to have additional fallbacks to parse other timestamp types (such as Unix millisecond/microsecond timestamps).