### PR TITLE
fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This builds the binary inside an Alpine Linux container, which is small
-FROM alpine:3.3
+FROM alpine:3.6
 MAINTAINER Ben Hartshorne <ben@honeycomb.io>
 
 # Set us up so we can build the binary
@@ -18,6 +18,7 @@ RUN apk add --update \
         git \
         openssl \
         ca-certificates \
+        musl-dev \
     && ver=$(git rev-parse --short HEAD) \
     && git clean -f \
     && rm -rf .git \


### PR DESCRIPTION
The first issue I ran into was:

```
package context: unrecognized import path "context"
```

Most likely due to an outdated go version, so I upgraded to alpine 3.6.

The second issue was:

```
# github.com/honeycombio/honeytail
/usr/lib/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/lib/gcc/x86_64-alpine-linux-musl/6.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find Scrt1.o: No such file or directory
/usr/lib/gcc/x86_64-alpine-linux-musl/6.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find crti.o: No such file or directory
/usr/lib/gcc/x86_64-alpine-linux-musl/6.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lpthread
/usr/lib/gcc/x86_64-alpine-linux-musl/6.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lssp_nonshared
collect2: error: ld returned 1 exit status
```

I followed the suggestion from https://github.com/etsy/hound/issues/238 and added the `musl-dev` package, and that seemed to fix it!