### PR TITLE
Add support for parsing floating point timestamps, like nginx $msec

### DIFF
--- a/httime/httime.go
+++ b/httime/httime.go
@@ -40,6 +40,7 @@ var (
 		"timestamp", "Timestamp", "TimeStamp",
 		"date", "Date",
 		"datetime", "Datetime", "DateTime",
+		"msec",
 	}
 	// reference: http://man7.org/linux/man-pages/man3/strftime.3.html
 	convertMapping = map[string]string{
@@ -126,6 +127,8 @@ func GetTimestamp(m map[string]interface{}, timeFieldName, timeFieldFormat strin
 				timeStr = v
 			case int:
 				timeStr = strconv.Itoa(v)
+			case float64:
+				timeStr = strconv.FormatFloat(v, 'f', -1, 64)
 			default:
 				warnAboutTime(timeFieldName, t, timeFoundImproperTypeMsg)
 				ts = Now()

--- a/parsers/nginx/nginx.go
+++ b/parsers/nginx/nginx.go
@@ -174,5 +174,9 @@ func (n *Parser) getTimestamp(evMap map[string]interface{}) time.Time {
 		return httime.GetTimestamp(evMap, "time_iso8601", iso8601TimeLayout)
 	}
 
+	if _, ok := evMap["msec"]; ok {
+		return httime.GetTimestamp(evMap, "msec", "")
+	}
+
 	return httime.GetTimestamp(evMap, "", "")
 }

--- a/parsers/nginx/nginx_test.go
+++ b/parsers/nginx/nginx_test.go
@@ -155,6 +155,8 @@ func TestGetTimestamp(t *testing.T) {
 	userDefinedTimeFormat := "2006-01-02T15:04:05.9999Z"
 	exampleCustomFormatTimestamp := "2017-07-31T20:40:57.980264Z"
 	t3, _ := time.ParseInLocation(userDefinedTimeFormat, exampleCustomFormatTimestamp, time.UTC)
+	t4 := time.Unix(1444263986, 250000000)
+	msec := 1444263986.25
 	testCases := []struct {
 		desc      string
 		conf      Options
@@ -259,6 +261,18 @@ func TestGetTimestamp(t *testing.T) {
 				"foo": "bar",
 			},
 			retval: t3,
+		},
+		{
+			desc: "timestamp in milliseconds",
+			conf: Options{},
+			input: map[string]interface{}{
+				"foo":  "bar",
+				"msec": msec,
+			},
+			postMunge: map[string]interface{}{
+				"foo": "bar",
+			},
+			retval: t4,
 		},
 	}
 


### PR DESCRIPTION
The only way to get more than second precision in nginx is to use the $msec variable, which has millisecond precision. Honeytail recognizes it as a floating point number and converts it, but then fails to recognize that as a valid timestamp because it's not a string.

This PR allows honeytail to automatically recognize the msec field (to skip some searching during parsing) and also to recognize a floating point timestamp as a timestamp in seconds.

Unfortunately, without a refactor, we can't retain the originally parse precision, we have to go to string then back to float and then break that float into a second and nanosecond part, which means we lose precision somewhere around the microsecond level. I am totally cool with that, just letting you know here that there are rounding issues.

All in all, this means that by including $msec in your log line *instead of `time_local` or `time_iso8601`* (because those are tried first) you can get millisecond precision in your starting timestamps. This is especially useful for small traces.

Thanks,
Nick