### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/parsers/regex/regex.go
+++ b/parsers/regex/regex.go
@@ -100,7 +100,7 @@ type RegexLineParser struct {
 	lineRegexes []*regexp.Regexp
 }
 
-// RegexLineParser factory
+// NewRegexLineParser factory
 func NewRegexLineParser(regexStrs []string) (*RegexLineParser, error) {
 	lineRegexes, err := ParseLineRegexes(regexStrs)
 	if err != nil {


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?