### PR TITLE
If --debug_stdout is set, we don't need a write key

### DIFF
--- a/main.go
+++ b/main.go
@@ -181,12 +181,16 @@ func main() {
 	addParserDefaultOptions(&options)
 	sanityCheckOptions(&options)
 
-	if _, err := libhoney.VerifyWriteKey(libhoney.Config{
-		APIHost:  options.APIHost,
-		WriteKey: options.Reqs.WriteKey,
-	}); err != nil {
-		fmt.Fprintln(os.Stderr, "Could not verify Honeycomb write key: ", err)
-		os.Exit(1)
+	if !options.DebugOut {
+		if _, err := libhoney.VerifyWriteKey(libhoney.Config{
+			APIHost:  options.APIHost,
+			WriteKey: options.Reqs.WriteKey,
+		}); err != nil {
+			fmt.Fprintln(os.Stderr, "Could not verify Honeycomb write key: ", err)
+			os.Exit(1)
+		}
+	} else {
+		logrus.Debug("skipping Honeycomb write key verification, because --debug_stdout is set...")
 	}
 	run(context.Background(), options)
 }
@@ -269,7 +273,7 @@ func sanityCheckOptions(options *GlobalOptions) {
 		fmt.Println("Parser required to be specified with the --parser flag.")
 		usage()
 		os.Exit(1)
-	case options.Reqs.WriteKey == "" || options.Reqs.WriteKey == "NULL":
+	case (options.Reqs.WriteKey == "" || options.Reqs.WriteKey == "NULL") && (!options.DebugOut):
 		fmt.Println("Write key required to be specified with the --writekey flag.")
 		usage()
 		os.Exit(1)

--- a/vendor/github.com/honeycombio/libhoney-go/libhoney.go
+++ b/vendor/github.com/honeycombio/libhoney-go/libhoney.go
@@ -582,8 +582,10 @@ func (e *Event) SendPresampled() error {
 	if e.APIHost == "" {
 		return errors.New("No APIHost for Honeycomb. Can't send to the Great Unknown.")
 	}
-	if e.WriteKey == "" {
-		return errors.New("No WriteKey specified. Can't send event.")
+	if e.WriteKey == "" { // TODO: this is incompatible with honeycombio/libhoney-go, will need revisiting when vendor'd lib is updated
+		if txType := reflect.TypeOf(tx); txType.String() != "*libhoney.WriterOutput" {
+			return errors.New("No WriteKey specified. Can't send event.")
+		}
 	}
 	if e.Dataset == "" {
 		return errors.New("No Dataset for Honeycomb. Can't send datasetless.")


### PR DESCRIPTION
Note: the change in the vendor'd honeycombio/libhoney-go is not compatible with upstream api changes, and will need to be revisited, probably soon