### PR TITLE
Multiline json

### DIFF
--- a/parsers/htjson/htjson_test.go
+++ b/parsers/htjson/htjson_test.go
@@ -88,7 +88,7 @@ func TestProcessLinesHandlesMultilineJSONInput(t *testing.T) {
 
 	// TODO I'm sure there's a more correct way to do this, but it escapes me at
 	// the moment
-	time.Sleep(5 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	expected := 3
 	found := len(outputEvents)


### PR DESCRIPTION
Also tested manually, using 
`cat multiline.log | honeytail --dataset some-data --parser json  --debug_stdout --debug  -f -` (note: `-k` is missing, my branch was rebased on https://github.com/honeycombio/honeytail/pull/132)
against a file multiline.log:
```json
"unfinished log item": 100
}
{
  "foo": 1,
  "bar": 2
}

{ "bar": 3
}

{

  "foo": "{"
}

{
 "deadkey": 1

```

Results in two errors (for the incomplete objects at beginning and end) and three successfully parsed events.