### PR TITLE
[httime] Enable GetTimestamp to handle time.Time values

### DIFF
--- a/httime/httime.go
+++ b/httime/httime.go
@@ -129,6 +129,9 @@ func GetTimestamp(m map[string]interface{}, timeFieldName, timeFieldFormat strin
 				timeStr = strconv.Itoa(v)
 			case float64:
 				timeStr = strconv.FormatFloat(v, 'f', -1, 64)
+			case time.Time:
+				// it's a time.Time struct - we can just return it
+				return v
 			default:
 				warnAboutTime(timeFieldName, t, timeFoundImproperTypeMsg)
 				ts = Now()

--- a/httime/httime_test.go
+++ b/httime/httime_test.go
@@ -250,6 +250,14 @@ func TestGetTimestampCustomFormat(t *testing.T) {
 	}
 }
 
+func TestGetTimestampTypeTime(t *testing.T) {
+	expected := time.Now()
+	resp := GetTimestamp(map[string]interface{}{"real_time_key": expected}, "real_time_key", "")
+	if !resp.Equal(expected) {
+		t.Errorf("resp time %s didn't match expected time %s", resp, expected)
+	}
+}
+
 func TestCommaInTimestamp(t *testing.T) {
 	commaTimes := []testTimestamp{
 		{ // test commas as the fractional portion separator


### PR DESCRIPTION
Prereq for https://github.com/honeycombio/honeycomb-kubernetes-agent/issues/35

We assume we're processing lines into string, int, or float values - but there are use cases where the field map passed to GetTimestamp can have an actual time.Time value. If requested explicitly in timeFieldName, we should just return the Time value we already have.