### PR TITLE
Keep retrying if logfile is missing

### DIFF
--- a/honeytail.service
+++ b/honeytail.service
@@ -8,6 +8,8 @@ KillMode=process
 Restart=on-failure
 User=honeycomb
 Group=honeycomb
+RestartSec=5
+StartLimitInterval=0
 
 [Install]
 Alias=honeytail honeytail.service


### PR DESCRIPTION
Fixes a race condition between honeytail starting and the log file
being created by continuously restarting honeytail until the file is
found.

Closes #125.