### PR TITLE
Debug log command line arguments

### DIFF
--- a/main.go
+++ b/main.go
@@ -208,7 +208,7 @@ func setVersionUserAgent(backfill bool, parserName string) {
 	libhoney.UserAgentAddition = fmt.Sprintf("honeytail/%s (%s)", version, parserName)
 }
 
-// handleOtherModes takse care of all flags that say we should just do something
+// handleOtherModes takes care of all flags that say we should just do something
 // and exit rather than actually parsing logs
 func handleOtherModes(fp *flag.Parser, modes OtherModes) {
 	if modes.Version {


### PR DESCRIPTION
There are a variety of scenarios (shell script with variable interpolation, k8s configuration) where it'd be useful to be able to see at a glance what arguments are being parsed by honeytail to speed up troubleshooting. This should make it easier to see how honeytail is being run.