### PR TITLE
Fixes package version to always start with digit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
                 bename: tar_honeytail
                 becommand: tar -cvf /tmp/honeytail.tar /tmp/honeytail
             - run: cp /tmp/honeytail.tar ~/artifacts/
-            - run: tar -cvf ~/artifacts/honeytail_all.tar artifacts/honeytail*
+            - run: tar -cvf ~/artifacts/honeytail_all.tar ~/artifacts/honeytail*
             - persist_to_workspace:
                 root: ~/
                 paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,9 +100,9 @@ jobs:
                 bename: tar_honeytail
                 becommand: tar -cvf /tmp/honeytail.tar /tmp/honeytail
             - run: cp /tmp/honeytail.tar artifacts/
-            - run: tar -cvf artifacts/honeytail_all.tar artifacts/honeytail*
+            - run: tar -cvf ~/artifacts/honeytail_all.tar artifacts/honeytail*
             - persist_to_workspace:
-                root: .
+                root: ~/
                 paths:
                   - artifacts/honeytail_all.tar
             - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
                 paths:
                   - artifacts/honeytail_all.tar
             - store_artifacts:
-                path: artifacts/
+                path: ~/artifacts/
 
   publish:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
                 becommand: ./build-pkg.sh -m amd64 -v "${CIRCLE_TAG}" -t rpm
             - run: echo "finished build_debs" && find . -ls
             - run: echo "finished build_debs" && find $GOPATH/bin -ls
-            - run: mkdir -v artifacts; cp -v honeytail*.{deb,rpm} artifacts/
+            - run: mkdir -v ~/artifacts; cp -v honeytail*.{deb,rpm} ~/artifacts/
             - run: |
                 mkdir /tmp/honeytail
                 cp $GOPATH/bin/* /tmp/honeytail/
@@ -99,7 +99,7 @@ jobs:
             - buildevents/berun:
                 bename: tar_honeytail
                 becommand: tar -cvf /tmp/honeytail.tar /tmp/honeytail
-            - run: cp /tmp/honeytail.tar artifacts/
+            - run: cp /tmp/honeytail.tar ~/artifacts/
             - run: tar -cvf ~/artifacts/honeytail_all.tar artifacts/honeytail*
             - persist_to_workspace:
                 root: ~/

--- a/build-pkg.sh
+++ b/build-pkg.sh
@@ -32,7 +32,7 @@ fi
 
 fpm -s dir -n honeytail \
     -m "Honeycomb <team@honeycomb.io>" \
-    -v $version \
+    -v ${version#v} \
     -t $pkg_type \
     -a $arch \
     --pre-install=./preinstall \


### PR DESCRIPTION
Debian does not like "v1.x.x" version numbers and insists they start with a number.