### PR TITLE
Add duration conversion

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,3 +9,4 @@ Ian Wilkes
 Justin Hennessy
 Max Neunhoeffer
 Rick Branson
+Sean Hood

--- a/leash.go
+++ b/leash.go
@@ -379,6 +379,19 @@ func modifyEventContents(toBeSent chan event.Event, options GlobalOptions) chan 
 					for k, v := range parsedAddFields {
 						ev.Data[k] = v
 					}
+					// do time unit conversion
+					if options.DurationField != "" && options.DurationUnit != "" {
+						// does that column exist in the event? and is it a float64?
+						if duration, ok := ev.Data[options.DurationField].(float64); ok {
+							switch options.DurationUnit {
+							case "us":
+								ev.Data[options.DurationField] = duration / 1000
+							case "s":
+								ev.Data[options.DurationField] = duration * 1000
+							}
+						}
+
+					}
 					// get presampled field if it exists
 					if options.PreSampledField != "" {
 						var presampledRate int

--- a/leash.go
+++ b/leash.go
@@ -381,13 +381,20 @@ func modifyEventContents(toBeSent chan event.Event, options GlobalOptions) chan 
 					}
 					// do time unit conversion
 					if options.DurationField != "" && options.DurationUnit != "" {
-						// does that column exist in the event? and is it a float64?
-						if duration, ok := ev.Data[options.DurationField].(float64); ok {
+						switch v := ev.Data[options.DurationField].(type) {
+						case float64:
 							switch options.DurationUnit {
 							case "us":
-								ev.Data[options.DurationField] = duration / 1000
+								ev.Data[options.DurationField] = v / 1000
 							case "s":
-								ev.Data[options.DurationField] = duration * 1000
+								ev.Data[options.DurationField] = v * 1000
+							}
+						case int64:
+							switch options.DurationUnit {
+							case "us":
+								ev.Data[options.DurationField] = float64(v) / 1000
+							case "s":
+								ev.Data[options.DurationField] = float64(v) * 1000
 							}
 						}
 

--- a/leash_test.go
+++ b/leash_test.go
@@ -307,6 +307,23 @@ func TestAddField(t *testing.T) {
 	assert.Contains(t, ts.rsp.reqBody, `{"format":"json","newfield":"newval","second":"new"}`)
 }
 
+func TestDurationField(t *testing.T) {
+	opts := defaultOptions
+	ts := &testSetup{}
+	ts.start(t, &opts)
+	defer ts.close()
+	logFileName := ts.tmpdir + "/duration.log"
+	fh, _ := os.Create(logFileName)
+	defer fh.Close()
+	fmt.Fprintf(fh, `{"format":"json","request_time":10054}`)
+	opts.Reqs.LogFiles = []string{logFileName}
+	opts.DurationField = "request_time"
+	opts.DurationUnit = "us"
+	run(context.Background(), opts)
+	assert.Equal(t, ts.rsp.reqCounter, 1)
+	assert.Contains(t, ts.rsp.reqBody, `{"format":"json","request_time":10.054}`)
+}
+
 func TestLinePrefix(t *testing.T) {
 	opts := defaultOptions
 	// linePrefix of "Nov 13 10:19:31 app23 process.port[pid]: "

--- a/main.go
+++ b/main.go
@@ -86,6 +86,8 @@ type GlobalOptions struct {
 	MinSampleRate       int      `long:"dynsample_minimum" description:"if the rate of traffic falls below this, dynsampler won't sample" default:"1"`
 	JSONFields          []string `long:"json_field" description:"JSON fields encoded as string to unescape and properly parse before sending"`
 	FilterFiles         []string `short:"F" long:"filter-file" description:"Log file(s) to exclude from --file glob. Can specify multiple times, including multiple globs."`
+	DurationField       string   `long:"duration_field" description:"For the field listed, convert duration into milliseconds. To be used in conjunction with --duration_unit"`
+	DurationUnit        string   `long:"duration_unit" description:"Specify the unit of time that the duration field uses. Allowed values: us, s"`
 
 	Reqs  RequiredOptions `group:"Required Options"`
 	Modes OtherModes      `group:"Other Modes"`
@@ -271,6 +273,7 @@ func addParserDefaultOptions(options *GlobalOptions) {
 	case options.Reqs.ParserName == "nginx":
 		// automatically normalize the request when using the nginx parser
 		options.RequestShape = append(options.RequestShape, "request")
+		options.DurationField = "request_time"
 	}
 	if options.Reqs.ParserName != "mysql" {
 		// mysql is the only parser that requires in-parser sampling because it has

--- a/main.go
+++ b/main.go
@@ -273,7 +273,10 @@ func addParserDefaultOptions(options *GlobalOptions) {
 	case options.Reqs.ParserName == "nginx":
 		// automatically normalize the request when using the nginx parser
 		options.RequestShape = append(options.RequestShape, "request")
-		options.DurationField = "request_time"
+		// automatically set the duration field if it's not set
+		if options.DurationField == "" {
+			options.DurationField = "request_time"
+		}
 	}
 	if options.Reqs.ParserName != "mysql" {
 		// mysql is the only parser that requires in-parser sampling because it has


### PR DESCRIPTION
Certain applications (httpd in my case) output their duration in microseconds
however honeycomb assumes time is in milliseconds. This PR adds two configuration
options to help with this conversion before the events are sent.

`DurationField / --duration_field`: This option is where you set the field you
wish to convert.

`DurationUnit / --duration_unit`: This option is where you set the unit of the
incoming duration. Accepted options: `s` (seconds) and `us` (microseconds).

For the `nginx` parser, we default to `request_time` so we only have to configure `DurationUnit` in most cases.

Discussion: https://honeycombpollinators.slack.com/archives/C4T3A32CX/p1583938457301600