### PR TITLE
bump alpine to 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This builds the binary inside an Alpine Linux container, which is small
-FROM alpine:3.6
+FROM alpine:3.11
 MAINTAINER Ben Hartshorne <ben@honeycomb.io>
 
 # Set us up so we can build the binary


### PR DESCRIPTION
It was failing on the older golang version with:

```
package math/bits: unrecognized import path "math/bits" (import path does not begin with hostname)
package github.com/vmihailenco/msgpack/v4: cannot find package "github.com/vmihailenco/msgpack/v4" in any of:
	/usr/lib/go/src/github.com/vmihailenco/msgpack/v4 (from $GOROOT)
	/gopath/src/github.com/vmihailenco/msgpack/v4 (from $GOPATH)
```