### PR TITLE
expose api host flag in help docs

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ var validParsers = []string{
 
 // GlobalOptions has all the top level CLI flags that honeytail supports
 type GlobalOptions struct {
-	APIHost    string `hidden:"true" long:"api_host" description:"Host for the Honeycomb API" default:"https://api.honeycomb.io/"`
+	APIHost    string `long:"api_host" description:"Host for the Honeycomb API" default:"https://api.honeycomb.io/"`
 	TailSample bool   `hidden:"true" description:"When true, sample while tailing. When false, sample post-parser events"`
 
 	ConfigFile string `short:"c" long:"config" description:"Config file for honeytail in INI format." no-ini:"true"`


### PR DESCRIPTION
Being able to set the API host to something other than api.honeycomb.io used to be a thing that nobody ever did except for Honeycomb itself. With a few client side proxies that is no longer the case. Stop hiding this flag from help output.

Closes #152 