### PR TITLE
Fix arangodb test race

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
             - checkout
             - buildevents/berun:
                 bename: go_test
-                becommand: go test --timeout 5s -v ./...
+                becommand: go test --timeout 10s -v ./...
 
   build:
     executor: linuxgo

--- a/parsers/arangodb/arangodb.go
+++ b/parsers/arangodb/arangodb.go
@@ -8,13 +8,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/honeycombio/honeytail/event"
 	"github.com/honeycombio/honeytail/httime"
 	"github.com/honeycombio/honeytail/parsers"
+	"github.com/sirupsen/logrus"
 )
 
-const numParsers = 20
+const defaultNumParsers = 20
 
 const (
 	iso8601UTCTimeFormat   = "2006-01-02T15:04:05Z"
@@ -42,6 +42,7 @@ var timestampFormats = []string{
 
 // Options type for line parser, so far there are none.
 type Options struct {
+	numParsers int
 }
 
 // Parser for log lines.
@@ -169,6 +170,10 @@ func (p *Parser) Init(options interface{}) error {
 // ProcessLines method for Parser.
 func (p *Parser) ProcessLines(lines <-chan string, send chan<- event.Event, prefixRegex *parsers.ExtRegexp) {
 	wg := sync.WaitGroup{}
+	numParsers := defaultNumParsers
+	if p.conf.numParsers > 0 {
+		numParsers = p.conf.numParsers
+	}
 	for i := 0; i < numParsers; i++ {
 		wg.Add(1)
 		go func() {

--- a/parsers/arangodb/arangodb_test.go
+++ b/parsers/arangodb/arangodb_test.go
@@ -68,7 +68,7 @@ func TestProcessLines(t *testing.T) {
 		},
 	}
 	m := &Parser{
-		conf:       Options{},
+		conf:       Options{numParsers: 1},
 		lineParser: &ArangoLineParser{},
 	}
 	lines := make(chan string)


### PR DESCRIPTION
The test assumes that lines are processed in the order that they've been injected into the channel, which isn't necessarily true due to lines being processed by different goroutines. Add the ability to specify the number of goroutines used for processing, and set it to 1 during the test.

Also bumped test run time up to 10 seconds from 5 - this was causing some tests to fail unexpectedly.