### PR TITLE
[honeytail] Fix builds so we can release v1.1.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,8 +125,8 @@ jobs:
                 aws-secret-access-key: AWS_SECRET_ACCESS_KEY
                 aws-region: AWS_REGION
             - buildevents/berun:
-                bename: sync artifacts to s3
-                becommand: aws s3 sync ~/artifacts s3://honeycomb-builds/honeycombio/honeytail/$VERSION/
+                bename: sync_s3_artifacts
+                becommand: aws s3 sync ~/artifacts s3://honeycomb-builds/honeycombio/honeytail/${VERSION}/
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
             - store_artifacts:
                 path: ~/artifacts
 
-  publish:
+  publish_github:
     docker:
       - image: cibuilds/github:0.13.0
     steps:
@@ -106,21 +106,27 @@ jobs:
           steps:
             - attach_workspace:
                 at: ~/
-            # - run:
-            #     name: "Publish Release on GitHub"
-            #     command: |
-            #       echo "about to publish to tag ${CIRCLE_TAG}"
-            #       ls -l ~/artifacts/*
-            #       ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
+            - run:
+                name: "Publish Release on GitHub"
+                command: |
+                  echo "about to publish to tag ${CIRCLE_TAG}"
+                  ls -l ~/artifacts/*
+                  ghr -draft -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
+  publish_s3:
+    executor: linuxgo
+    steps:
+      - buildevents/with_job_span:
+          steps:
+            - attach_workspace:
+                at: ~/
             - aws-cli/install
             - aws-cli/configure:
                 aws-access-key-id: AWS_ACCESS_KEY_ID
                 aws-secret-access-key: AWS_SECRET_ACCESS_KEY
                 aws-region: AWS_REGION
-            - run: |
-                for artifact in ~/artifacts/*; do
-                  aws s3 cp $artifact s3://honeycomb-builds/honeycombio/honeytail/$VERSION/
-                done
+            - buildevents/berun:
+                bename: sync artifacts to s3
+                becommand: aws s3 sync ~/artifacts s3://honeycomb-builds/honeycombio/honeytail/$VERSION/
 
 workflows:
   build:
@@ -156,7 +162,17 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
-      - publish:
+      - publish_github:
+          context: Honeycomb Secrets
+          requires:
+            - build
+            - hold
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - publish_s3:
           context: Honeycomb Secrets
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,20 +82,14 @@ jobs:
             - run: mkdir -p ~/artifacts
             - buildevents/berun:
                 bename: build_deb_amd64
-                becommand: |
-                  ./build-pkg.sh -m amd64 -v "${CIRCLE_TAG}" -t deb
-                  mv *.deb ~/artifacts
+                becommand: ./build-pkg.sh -m amd64 -v "${CIRCLE_TAG}" -t deb && mv *.deb ~/artifacts
             - buildevents/berun:
                 bename: build_deb_arm64
-                becommand: |
-                  ./build-pkg.sh -m arm64 -v "${CIRCLE_TAG}" -t deb
-                  mv *.deb ~/artifacts
+                becommand: ./build-pkg.sh -m arm64 -v "${CIRCLE_TAG}" -t deb && mv *.deb ~/artifacts
             - buildevents/berun:
                 bename: build_rpm_amd64
-                becommand: |
-                  ./build-pkg.sh -m amd64 -v "${CIRCLE_TAG}" -t rpm
-                  mv *.rpm ~/artifacts
-            - run: echo "finished build_debs" && find ~/ -ls
+                becommand: ./build-pkg.sh -m amd64 -v "${CIRCLE_TAG}" -t rpm && mv *.rpm ~/artifacts
+            - run: echo "finished build_debs" && find ~/artifacts -ls
             - run: echo "finished build_debs" && find $GOPATH/bin -ls
             - persist_to_workspace:
                 root: ~/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,20 +153,10 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - hold:
-          type: approval # presents manual approval button in the UI
-          requires:
-            - build
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
       - publish_github:
           context: Honeycomb Secrets
           requires:
             - build
-            - hold
           filters:
             tags:
               only: /^v.*/
@@ -176,7 +166,6 @@ workflows:
           context: Honeycomb Secrets
           requires:
             - build
-            - hold
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
                 command: |
                   echo "about to publish to tag ${CIRCLE_TAG}"
                   ls -l ~/artifacts/*
-                  ghr -draft -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
+                  ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
   publish_s3:
     executor: linuxgo
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,12 +106,12 @@ jobs:
           steps:
             - attach_workspace:
                 at: ~/
-            - run:
-                name: "Publish Release on GitHub"
-                command: |
-                  echo "about to publish to tag ${CIRCLE_TAG}"
-                  ls -l ~/artifacts/*
-                  ghr -draft -replace -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
+            # - run:
+            #     name: "Publish Release on GitHub"
+            #     command: |
+            #       echo "about to publish to tag ${CIRCLE_TAG}"
+            #       ls -l ~/artifacts/*
+            #       ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
             - aws-cli/install
             - aws-cli/configure:
                 aws-access-key-id: AWS_ACCESS_KEY_ID

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
 
   publish:
     docker:
-      - image: cibuilds/github:0.12.1
+      - image: cibuilds/github:0.13.0
     steps:
       - buildevents/with_job_span:
           steps:
@@ -111,7 +111,7 @@ jobs:
                 command: |
                   echo "about to publish to tag ${CIRCLE_TAG}"
                   ls -l ~/artifacts/*
-                  ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
+                  ghr -draft -replace -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
             - aws-cli/install
             - aws-cli/configure:
                 aws-access-key-id: AWS_ACCESS_KEY_ID

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,15 @@ jobs:
                   echo "about to publish to tag ${CIRCLE_TAG}"
                   ls -l ~/artifacts/*
                   ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
+            - aws-cli/install
+            - aws-cli/configure:
+                aws-access-key-id: AWS_ACCESS_KEY_ID
+                aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+                aws-region: AWS_REGION
+            - run: |
+                for artifact in ~/artifacts/*; do
+                  aws s3 cp $artifact s3://honeycomb-builds/honeycombio/honeytail/$VERSION/
+                done
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
                 aws-region: AWS_REGION
             - buildevents/berun:
                 bename: sync_s3_artifacts
-                becommand: aws s3 sync ~/artifacts s3://honeycomb-builds/honeycombio/honeytail/${VERSION}/
+                becommand: aws s3 sync ~/artifacts s3://honeycomb-builds/honeycombio/honeytail/${CIRCLE_TAG}/
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,34 +79,30 @@ jobs:
                 bename: gem_install
                 becommand: sudo gem install fpm
             - run: $GOPATH/bin/honeytail-linux-amd64 --write_default_config > ./honeytail.conf
+            - run: mkdir -p ~/artifacts
             - buildevents/berun:
                 bename: build_deb_amd64
-                becommand: ./build-pkg.sh -m amd64 -v "${CIRCLE_TAG}" -t deb
+                becommand: |
+                  ./build-pkg.sh -m amd64 -v "${CIRCLE_TAG}" -t deb
+                  mv *.deb ~/artifacts
             - buildevents/berun:
                 bename: build_deb_arm64
-                becommand: ./build-pkg.sh -m arm64 -v "${CIRCLE_TAG}" -t deb
+                becommand: |
+                  ./build-pkg.sh -m arm64 -v "${CIRCLE_TAG}" -t deb
+                  mv *.deb ~/artifacts
             - buildevents/berun:
                 bename: build_rpm_amd64
-                becommand: ./build-pkg.sh -m amd64 -v "${CIRCLE_TAG}" -t rpm
-            - run: echo "finished build_debs" && find . -ls
+                becommand: |
+                  ./build-pkg.sh -m amd64 -v "${CIRCLE_TAG}" -t rpm
+                  mv *.rpm ~/artifacts
+            - run: echo "finished build_debs" && find ~/ -ls
             - run: echo "finished build_debs" && find $GOPATH/bin -ls
-            - run: mkdir -v ~/artifacts; cp -v honeytail*.{deb,rpm} ~/artifacts/
-            - run: |
-                mkdir /tmp/honeytail
-                cp $GOPATH/bin/* /tmp/honeytail/
-                cp ./honeytail.conf /tmp/honeytail/
-                find /tmp/honeytail -ls
-            - buildevents/berun:
-                bename: tar_honeytail
-                becommand: tar -cvf /tmp/honeytail.tar /tmp/honeytail
-            - run: cp /tmp/honeytail.tar ~/artifacts/
-            - run: tar -cvf ~/artifacts/honeytail_all.tar ~/artifacts/honeytail*
             - persist_to_workspace:
                 root: ~/
                 paths:
-                  - artifacts/honeytail_all.tar
+                  - artifacts
             - store_artifacts:
-                path: ~/artifacts/
+                path: ~/artifacts
 
   publish:
     docker:
@@ -115,14 +111,13 @@ jobs:
       - buildevents/with_job_span:
           steps:
             - attach_workspace:
-                at: artifacts
+                at: ~/
             - run:
                 name: "Publish Release on GitHub"
                 command: |
                   echo "about to publish to tag ${CIRCLE_TAG}"
-                  tar -xvf artifacts/honeytail_all.tar
-                  ls -l *
-                  ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/honeytail*.{deb,rpm} honeytail.tar
+                  ls -l ~/artifacts/*
+                  ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
 
 workflows:
   build:
@@ -149,9 +144,20 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - publish:
+      - hold:
+          type: approval # presents manual approval button in the UI
           requires:
             - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - publish:
+          context: Honeycomb Secrets
+          requires:
+            - build
+            - hold
           filters:
             tags:
               only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Honeytail Changelog
+
+## 1.1.2
+
+Improvements:
+
+- Add informational messaging about how the `backfill` option interacts with rate limiting.


### PR DESCRIPTION
### Summary
This change fixes our automated builds so that we can deploy artifacts to Github Releases and S3 automatically.
* Adds CHANGELOG.md to track changes.

There are no changes to the `honeytail` binary, just changes to our build and deployment tooling.