### PR TITLE
Interface() panics if called on an unexported field.

### DIFF
--- a/main.go
+++ b/main.go
@@ -205,16 +205,23 @@ func structToString(s interface{}) string {
 	t := v.Type()
 	fields := make([]string, v.NumField())
 
+	isExported := func(s string) bool {
+		f := s[0:1]
+		return f == strings.ToUpper(f)
+	}
+
 	for i := 0; i < v.NumField(); i++ {
 		if v.Field(i).Kind() == reflect.Struct {
 			fields[i] = structToString(v.Field(i).Interface())
 		} else {
 			name := t.Field(i).Name
-			value := v.Field(i).Interface()
-			if name == "WriteKey" {
-				value = "[REDACTED]"
+			if isExported(name) {
+				value := v.Field(i).Interface()
+				if name == "WriteKey" {
+					value = "[REDACTED]"
+				}
+				fields[i] = fmt.Sprintf("%s.%s=%v", t, name, value)
 			}
-			fields[i] = fmt.Sprintf("%s.%s=%v", t, name, value)
 		}
 	}
 	return strings.Join(fields, ",")


### PR DESCRIPTION
This just checks that the first character of the field name is upper case and therefore exported.