### PR TITLE
Release 1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Honeytail Changelog
 
+## 1.1.4
+
+Bug Fixes:
+
+- Fixed issue with bad tag for 1.1.3 causing issues with go modules. No other changes.
+
 ## 1.1.3
 
 Bug Fixes:


### PR DESCRIPTION
Pushing a new v1.1.4 release, since the 1.1.3 tag was broken due to being deleted previous while testing builds. No code changes.