### PR TITLE
Use public ENV context in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ workflows:
             tags:
               only: /.*/
       - publish_github:
-          context: Honeycomb Secrets
+          context: Honeycomb Secrets for Public Repos
           requires:
             - build
           filters:
@@ -165,7 +165,7 @@ workflows:
             branches:
               ignore: /.*/
       - publish_s3:
-          context: Honeycomb Secrets
+          context: Honeycomb Secrets for Public Repos
           requires:
             - build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,22 +134,26 @@ workflows:
   build:
     jobs:
       - setup:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
       - watch:
+          context: Honeycomb Secrets for Public Repos
           requires:
             - setup
           filters:
             tags:
               only: /.*/
       - test:
+          context: Honeycomb Secrets for Public Repos
           requires:
             - setup
           filters:
             tags:
               only: /.*/
       - build:
+          context: Honeycomb Secrets for Public Repos
           requires:
             - test
           filters:


### PR DESCRIPTION
* currently secrets are pulled from the project env variables in CircleCI
* using a shared context consolidates secrets storage, makes for easier secret updates
* majority of other repos already use the shared context, looks like this was set up
a while back before the context was created
* secret values are unchanged from what's currently in the project env variables