### PR TITLE
Publishing to s3 and gh requires that the packages are built first

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,7 @@ workflows:
           context: Honeycomb Secrets for Public Repos
           requires:
             - test
+            - build_packages
           filters:
             tags:
               only: /^v.*/
@@ -123,6 +124,7 @@ workflows:
           context: Honeycomb Secrets for Public Repos
           requires:
             - test
+            - build_packages
           filters:
             tags:
               only: /^v.*/


### PR DESCRIPTION
Are unit tests for Circle configs a thing? :)