### PR TITLE
tell Dependabot to use our maintenance label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    labels:
+      - "type: maintenance"
     reviewers:
       - "honeycombio/integrations-team"


### PR DESCRIPTION
Use our labeling scheme instead of calling it "dependencies"