### PR TITLE
Prepare v1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Honeytail Changelog
 
+## 1.4.0
+
+Improvements:
+
+- Add tail option to generate hash per state file when tailing multile files with same name (#191)
+- Include note about quoted table/column names in PG (#186)
+
+Maintenance:
+
+- Teach Dependabot to use our maintenance labels (#180 & #181)
+- Bump github.com/go-sql-driver/mysql from 1.5.0 to 1.6.0 (#188)
+- Bump github.com/klauspost/compress from 1.11.12 to 1.11.13 (#187)
+- Bump github.com/stretchr/testify from 1.5.1 to 1.7.0 (#169)
+- Bump github.com/honeycombio/libhoney-go from 1.12.4 to 1.15.2 (#171)
+- Bump github.com/klauspost/compress from 1.10.3 to 1.11.12 (#183)
+- Bump github.com/sirupsen/logrus from 1.4.2 to 1.8.1 (#184)
+
 ## 1.3.0
 
 Add rename_field flag that allows users to map fields to alternative field names.


### PR DESCRIPTION
Updates the changelog with changes since v1.3.0 release.