### PR TITLE
Generate statefile hash based on tailed file location

### DIFF
--- a/tail/tail.go
+++ b/tail/tail.go
@@ -417,12 +417,10 @@ func getStateFile(conf Config, filename string, numFiles int) string {
 		}
 	}
 
-	var stateFileName string
+	stateFileName := strings.TrimSuffix(filepath.Base(filename), ".log") + ".leash.state"
 	if conf.Options.HashStateFileDirPaths {
 		// generate hash based on filepath, in format 'filename.leash.state-{hash}'
-		stateFileName = strings.TrimSuffix(filepath.Base(filename), ".log") + ".leash.state" + fmt.Sprintf("-%x", sha1.Sum([]byte(confStateFile)))
-	} else {
-		stateFileName = strings.TrimSuffix(filepath.Base(filename), ".log") + ".leash.state"
+		stateFileName += fmt.Sprintf("-%x", sha1.Sum([]byte(filename)))
 	}
 	return filepath.Join(confStateFile, stateFileName)
 }

--- a/tail/tail_test.go
+++ b/tail/tail_test.go
@@ -320,9 +320,8 @@ func TestGetFileStateWithHashPathEnabled(t *testing.T) {
 		},
 	}
 
-	filename := "foobar.log"
-	osTempStatefilename := fmt.Sprintf("foobar.leash.state-%x", sha1.Sum([]byte(os.TempDir())))
-	tsTempStatefilename := fmt.Sprintf("foobar.leash.state-%x", sha1.Sum([]byte(ts.tmpdir)))
+	filename := "/var/logs/foobar.log"
+	statefilename := fmt.Sprintf("foobar.leash.state-%x", sha1.Sum([]byte(filename)))
 
 	existingStateFile := filepath.Join(ts.tmpdir, "existing.state")
 	ts.writeFile(t, existingStateFile, "")
@@ -334,13 +333,13 @@ func TestGetFileStateWithHashPathEnabled(t *testing.T) {
 		expected        string
 	}{
 		{existingStateFile, 1, existingStateFile},
-		{existingStateFile, 2, filepath.Join(os.TempDir(), osTempStatefilename)},
+		{existingStateFile, 2, filepath.Join(os.TempDir(), statefilename)},
 		{newStateFile, 1, newStateFile},
-		{newStateFile, 2, filepath.Join(os.TempDir(), osTempStatefilename)},
-		{ts.tmpdir, 1, filepath.Join(ts.tmpdir, tsTempStatefilename)},
-		{ts.tmpdir, 2, filepath.Join(ts.tmpdir, tsTempStatefilename)},
-		{"", 1, filepath.Join(os.TempDir(), osTempStatefilename)},
-		{"", 2, filepath.Join(os.TempDir(), osTempStatefilename)},
+		{newStateFile, 2, filepath.Join(os.TempDir(), statefilename)},
+		{ts.tmpdir, 1, filepath.Join(ts.tmpdir, statefilename)},
+		{ts.tmpdir, 2, filepath.Join(ts.tmpdir, statefilename)},
+		{"", 1, filepath.Join(os.TempDir(), statefilename)},
+		{"", 2, filepath.Join(os.TempDir(), statefilename)},
 	}
 
 	for _, tt := range tsts {

--- a/tail/tail_test.go
+++ b/tail/tail_test.go
@@ -351,6 +351,22 @@ func TestGetFileStateWithHashPathEnabled(t *testing.T) {
 		}
 	}
 }
+func TestStatefilesWithDifferentPathsGetDifferentHashes(t *testing.T) {
+	conf := Config{
+		Paths: make([]string, 3),
+		Options: TailOptions{
+			ReadFrom:              "start",
+			Stop:                  true,
+			HashStateFileDirPaths: true,
+		},
+	}
+
+	statefile1 := getStateFile(conf, "/var/logs/app-1/foobar.log", 1)
+	statefile2 := getStateFile(conf, "/var/logs/app-2/foobar.log", 1)
+	if statefile1 == statefile2 {
+		t.Error("state files with different paths should not be equel")
+	}
+}
 
 // boilerplate to spin up a httptest server, create tmpdir, etc.
 // to create an environment in which to run these tests

--- a/tail/tail_test.go
+++ b/tail/tail_test.go
@@ -364,7 +364,7 @@ func TestStatefilesWithDifferentPathsGetDifferentHashes(t *testing.T) {
 	statefile1 := getStateFile(conf, "/var/logs/app-1/foobar.log", 1)
 	statefile2 := getStateFile(conf, "/var/logs/app-2/foobar.log", 1)
 	if statefile1 == statefile2 {
-		t.Error("state files with different paths should not be equel")
+		t.Error("state files with different paths should not be equal")
 	}
 }
 


### PR DESCRIPTION
Fixes an issue from #191 where the statefile path is used to generate the hash, instead we should generate the hash based on the path for the tailed file.

Also simplifies the logic of when to append the hash.