### PR TITLE
Update Go to 1.16 & test cross-compilation in PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,11 @@ orbs:
 platform_matrix: &platform_matrix
   matrix:
     parameters:
-      os: &oses ["linux", "darwin", "windows"]
+      os: &oses ["linux", "darwin"] # <-- "windows" in the future!
       arch: &arches ["amd64", "arm64"]
-    exclude:
-      - os: "windows"
-      - arch: "arm64"
+    # exclude: # And when Windows comes, we'll need to exclude the Win+arm64 combo somehow
+    #   - os: "windows"
+    #   - arch: "arm64"
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,12 +41,12 @@ jobs:
           GOOS=<< parameters.os >> \
           GOARCH=<< parameters.arch >> \
           go build -ldflags "-X main.BuildID=${CIRCLE_TAG}" \
-          -o $GOPATH/bin/honeytail-<< parameters.os >>-<< parameters.arch >> \
+          -o ~/artifacts/honeytail-<< parameters.os >>-<< parameters.arch >> \
           .
       - persist_to_workspace:
           root: ~/
           paths:
-            - bin
+            - artifacts
 
   build_packages:
     docker:
@@ -56,12 +56,10 @@ jobs:
       - run: sudo apt-get -qq update
       - run: sudo apt-get install -y build-essential rpm ruby ruby-dev
       - run: sudo gem install fpm
-      - run: $GOPATH/bin/honeytail-linux-amd64 --write_default_config > ./honeytail.conf
-      - run: mkdir -p ~/artifacts
+      - run: ~/artifacts/honeytail-linux-amd64 --write_default_config > ./honeytail.conf
       - run: ./build-pkg.sh -m amd64 -v "${CIRCLE_TAG}" -t deb && mv *.deb ~/artifacts
       - run: ./build-pkg.sh -m arm64 -v "${CIRCLE_TAG}" -t deb && mv *.deb ~/artifacts
       - run: ./build-pkg.sh -m amd64 -v "${CIRCLE_TAG}" -t rpm && mv *.rpm ~/artifacts
-      - run: cp $GOPATH/bin/honeytail-* ~/artifacts
       - run: echo "finished builds" && find ~/artifacts -ls
       - persist_to_workspace:
           root: ~/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,27 +4,14 @@ orbs:
   aws-cli: circleci/aws-cli@0.1.13
   docker: circleci/docker@1.3.0
 
-
-commands:
-  go-build:
+platform_matrix: &platform_matrix
+  matrix:
     parameters:
-      os:
-        description: Target operating system
-        type: enum
-        enum: ["linux", "darwin", "windows"]
-        default: "linux"
-      arch:
-        description: Target architecture
-        type: enum
-        enum: ["amd64", "arm64"]
-        default: "amd64"
-    steps:
-      - run: |
-          GOOS=<< parameters.os >> \
-          GOARCH=<< parameters.arch >> \
-          go build -ldflags "-X main.BuildID=${CIRCLE_TAG}" \
-          -o $GOPATH/bin/honeytail-<< parameters.os >>-<< parameters.arch >> \
-          .
+      os: &oses ["linux", "darwin", "windows"]
+      arch: &arches ["amd64", "arm64"]
+    exclude:
+      - os: "windows"
+      - arch: "arm64"
 
 jobs:
   test:
@@ -34,26 +21,38 @@ jobs:
       - checkout
       - run: go test --timeout 10s -v ./...
 
+  go-build:
+    docker:
+      - image: circleci/golang:1.16
+    parameters:
+      os:
+        description: Target operating system
+        type: enum
+        enum: *oses
+        default: "linux"
+      arch:
+        description: Target architecture
+        type: enum
+        enum: *arches
+        default: "amd64"
+    steps:
+      - checkout
+      - run: |
+          GOOS=<< parameters.os >> \
+          GOARCH=<< parameters.arch >> \
+          go build -ldflags "-X main.BuildID=${CIRCLE_TAG}" \
+          -o $GOPATH/bin/honeytail-<< parameters.os >>-<< parameters.arch >> \
+          .
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - bin
+
   build_packages:
     docker:
       - image: circleci/golang:1.16
     steps:
       - checkout
-      - go-build:
-          os: linux
-          arch: amd64
-      - go-build:
-          os: linux
-          arch: arm64
-      - go-build:
-          os: darwin
-          arch: amd64
-      - go-build:
-          os: darwin
-          arch: arm64
-      - go-build:
-          os: windows
-          arch: amd64
       - run: sudo apt-get -qq update
       - run: sudo apt-get install -y build-essential rpm ruby ruby-dev
       - run: sudo gem install fpm
@@ -106,10 +105,18 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - go-build:
+          <<: *platform_matrix
+          requires:
+            - test
+          filters:
+            tags:
+              only: /.*/
       - build_packages:
           context: Honeycomb Secrets for Public Repos
           requires:
             - test
+            - go-build
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,14 +29,14 @@ commands:
 jobs:
   test:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.16
     steps:
       - checkout
       - run: go test --timeout 10s -v ./...
 
   build_packages:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.16
     steps:
       - checkout
       - go-build:

--- a/build-pkg.sh
+++ b/build-pkg.sh
@@ -36,7 +36,7 @@ fpm -s dir -n honeytail \
     -t $pkg_type \
     -a $arch \
     --pre-install=./preinstall \
-    $GOPATH/bin/honeytail-linux-${arch}=/usr/bin/honeytail \
+    ./artifacts/honeytail-linux-${arch}=/usr/bin/honeytail \
     ./honeytail.upstart=/etc/init/honeytail.conf \
     ./honeytail.service=/lib/systemd/system/honeytail.service \
     ./honeytail.conf=/etc/honeytail/honeytail.conf


### PR DESCRIPTION
* test and build with Go 1.16 

Not only is it the latest and greatest, it allows for darwin-arm64 builds.

* matrixify the 'go build' for os/arch 

Turn the parameterized 'go-build' command into a parameterized 'go-build' job. As a job separate from the packaging, this can be added to the 'build' workflow as a job to perform on pull requests and not only run on git taggings.

For example, on this PR ...

![a CI job flow diagram showing a "test" job as a dependency of four parallel "go-build-architecture-os" jobs](https://user-images.githubusercontent.com/517302/118312550-89e26180-b4bf-11eb-966f-f354b3d20afc.png)


* remove Windows from the build matrix

The amd64 version throws errors during the build:

    # github.com/honeycombio/honeytail/tail
    tail/tail.go:321:13: undefined: unix.Stat_t
    tail/tail.go:322:12: undefined: unix.Stat
    tail/tail.go:431:13: undefined: unix.Stat_t
    tail/tail.go:432:2: undefined: unix.Stat
    Exited with code exit status 2

Probably need to use os.Stat() instead?

Also, need to figure out how to exclude the Windows + arm64 combination from the matrix. If we can't get 'exclude:' to work here, we can [add a conditional to the job](https://circleci.com/docs/2.0/reusing-config/#defining-conditional-steps) to do nothing.