### PR TITLE
fix: package build job needs the workspace attached to get at output from previous build jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,8 @@ jobs:
     docker:
       - image: circleci/golang:1.16
     steps:
+      - attach_workspace:
+          at: ~/
       - checkout
       - run: sudo apt-get -qq update
       - run: sudo apt-get install -y build-essential rpm ruby ruby-dev

--- a/build-pkg.sh
+++ b/build-pkg.sh
@@ -36,7 +36,7 @@ fpm -s dir -n honeytail \
     -t $pkg_type \
     -a $arch \
     --pre-install=./preinstall \
-    ./artifacts/honeytail-linux-${arch}=/usr/bin/honeytail \
+    ~/artifacts/honeytail-linux-${arch}=/usr/bin/honeytail \
     ./honeytail.upstart=/etc/init/honeytail.conf \
     ./honeytail.service=/lib/systemd/system/honeytail.service \
     ./honeytail.conf=/etc/honeytail/honeytail.conf


### PR DESCRIPTION
Also reverts a change to where the build_pkg.sh script goes looking for the executable.