### PR TITLE
Update install docs for modern go versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Our complete list of parsers can be found in the [`parsers/` directory](parsers/
 Install from source:
 
 ```
-go get github.com/honeycombio/honeytail
+go install github.com/honeycombio/honeytail@latest
 ```
 
 to install to a specific path:
 
 ```
-GOPATH=/usr/local go get github.com/honeycombio/honeytail
+GOPATH=/usr/local go install github.com/honeycombio/honeytail@latest
 ```
 
 the binary will install to `/usr/local/bin/honeytail`


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- `go get` in go modules worlds is deprecated, long live modules!

## Short description of the changes

-

