### PR TITLE
[maint] update circle to cimg/go:1.18, update alpine to 3.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,14 +19,14 @@ platform_matrix: &platform_matrix
 jobs:
   test:
     docker:
-      - image: circleci/golang:1.17
+      - image: cimg/go:1.18
     steps:
       - checkout
       - run: go test --timeout 10s -v ./...
 
   go-build:
     docker:
-      - image: circleci/golang:1.17
+      - image: cimg/go:1.18
     parameters:
       os:
         description: Target operating system
@@ -53,7 +53,7 @@ jobs:
 
   build_packages:
     docker:
-      - image: circleci/golang:1.17
+      - image: cimg/go:1.18
     steps:
       - attach_workspace:
           at: ~/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This builds the binary inside an Alpine Linux container, which is small
-FROM alpine:3.11
+FROM alpine:3.13
 MAINTAINER Ben Hartshorne <ben@honeycomb.io>
 
 # Set us up so we can build the binary


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- closes #242 

## Short description of the changes

- update circle image to cimg/go:1.18 (which is currently up to 1.18.1)
- update Dockerfile alpine image to 3.13 (currently up to 3.13.10)

