### PR TITLE
fix(postgres): report query duration as duration_ms

### DIFF
--- a/parsers/postgresql/postgresql.go
+++ b/parsers/postgresql/postgresql.go
@@ -209,7 +209,7 @@ func (p *Parser) handleEvent(rawEvent []string) *event.Event {
 
 	if rawDuration, ok := slowQueryMeta["duration"]; ok {
 		duration, _ := strconv.ParseFloat(rawDuration, 64)
-		ev.Data["duration"] = duration
+		ev.Data["duration_ms"] = duration
 	} else {
 		logrus.WithField("query", query).Debug("Failed to find query duration in log line")
 	}


### PR DESCRIPTION
Per company documentation for auto-recognition for traces: https://docs.honeycomb.io/getting-data-in/tracing/troubleshooting/#honeycomb-is-not-recognizing-my-traces

## Which problem is this PR solving?

- #250

## Short description of the changes

- Reports duration under `duration_ms` vs. `duration`

