### PR TITLE
Prep release 1.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Honeytail Changelog
 
+## 1.7.1
+
+### Maintenance
+
+- Bump github.com/klauspost/compress from 1.15.5 to 1.15.8 (#255) | dependabot
+- fixes openSSL CVE
+
 ## 1.7.0
 
 ### Fixes


### PR DESCRIPTION

## Which problem is this PR solving?

- Fixes OpenSSL CVE by forcing a rebuild. 
- Includes a dependency bump.

