### PR TITLE
Don't delete a time field if we can't parse it as a time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,8 @@ For more advanced usage, options, and the ability to scrub or drop specific fiel
 
 ## Related Work
 
-In some cases, we've extracted out some generic work for a particular log format
+We've extracted out some generic work for a particular log format:
 
-- [mongodbtools](https://github.com/honeycombio/mongodbtools) contains logic specific to parsing various versions of MongoDB logs, and a script for capturing high-level statistics on the database server itself
 - [mysqltools](https://github.com/honeycombio/mysqltools) contains logic specific to normalizing MySQL queries
 
 ## Contributions

--- a/httime/httime.go
+++ b/httime/httime.go
@@ -152,16 +152,18 @@ func GetTimestamp(m map[string]interface{}, timeFieldName, timeFieldFormat strin
 		delete(m, timeFieldName)
 		return ts
 	}
+
 	// go through all the possible fields that might have a timestamp
 	// for the first one we find, if it's a string field, try and parse it
-	// if we succeed, stop looking. Otherwise keep trying
+	// if we succeed, stop looking. Otherwise keep trying.
 	for _, timeField := range possibleTimeFieldNames {
 		if t, found := m[timeField]; found {
 			timeStr, found := t.(string)
 			if found {
-				foundFieldName = timeField
 				ts = tryTimeFormats(timeStr, timeFieldFormat)
 				if !ts.IsZero() {
+					// Only set foundFieldName if we were able to parse it as a time
+					foundFieldName = timeField
 					break
 				}
 				warnAboutTime(timeField, t, timeFoundInvalidFormatMsg)
@@ -171,7 +173,9 @@ func GetTimestamp(m map[string]interface{}, timeFieldName, timeFieldFormat strin
 	if ts.IsZero() {
 		ts = Now()
 	}
-	delete(m, foundFieldName)
+	if foundFieldName != "" {
+		delete(m, foundFieldName)
+	}
 	return ts
 }
 

--- a/httime/httime.go
+++ b/httime/httime.go
@@ -131,7 +131,7 @@ func GetTimestamp(m map[string]interface{}, timeFieldName, timeFieldFormat strin
 				timeStr = strconv.FormatFloat(v, 'f', -1, 64)
 			case time.Time:
 				// it's a time.Time struct - we can just return it
-				return v
+				ts = v
 			default:
 				warnAboutTime(timeFieldName, t, timeFoundImproperTypeMsg)
 				ts = Now()


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes #238
- Fixes #239 

## Short description of the changes

- GetTimestamp violates its documented behavior (fails to delete the timestamp field) if a timestamp matches a certain format. This causes it to do that.
- GetTimestamp looks at a bunch of fields and tries to parse them as a timestamp. If it succeeds, it deletes the field. But there was a bug (see the referenced bug report). This fixes that bug.

