### PR TITLE
chore: use temp credentials for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - aws-cli/configure:
+      - aws-cli/setup:
           role-arn: "arn:aws:iam::702835727665:role/circleci-public-repos"
           role-session-name: "honeytail"
           aws-region: AWS_REGION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  aws-cli: circleci/aws-cli@0.1.13
+  aws-cli: circleci/aws-cli@3.2.0
   docker: circleci/docker@1.7.0
 
 platform_matrix: &platform_matrix
@@ -101,10 +101,9 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - aws-cli/install
       - aws-cli/configure:
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          role-arn: "arn:aws:iam::702835727665:role/circleci-public-repos"
+          role-session-name: "honeytail"
           aws-region: AWS_REGION
       - run:
           name: sync_s3_artifacts


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Use temp credentials for CI

## Short description of the changes

- Bump the orb version
- Use the role name instead of access keys

