### PR TITLE
feat: Add config option for log level

### DIFF
--- a/main.go
+++ b/main.go
@@ -92,6 +92,8 @@ type GlobalOptions struct {
 	FilterFiles         []string `short:"F" long:"filter-file" description:"Log file(s) to exclude from --file glob. May have multiple values, including multiple globs." yaml:"filter-file,omitempty"`
 	RenameFields        []string `long:"rename_field" description:"Format: 'before=after'. Rename field called 'before' from parsed lines to field name 'after' in Honeycomb events. May have multiple values." yaml:"rename_field,omitempty"`
 
+	LogLevel string `long:"log_level" description:"Set the log level. Valid values are 'debug', 'info', 'warn', 'error', 'fatal', 'panic'." default:"info" yaml:"log_level,omitempty"`
+
 	Reqs  RequiredOptions `group:"Required Options" yaml:"required_options,omitempty"`
 	Modes OtherModes      `group:"Other Modes" yaml:"-"`
 
@@ -174,6 +176,13 @@ See https://honeycomb.io/docs/connect/agent/ for more detailed usage instruction
 
 	if options.Debug {
 		logrus.SetLevel(logrus.DebugLevel)
+	} else if options.LogLevel != "" {
+		level, err := logrus.ParseLevel(options.LogLevel)
+		if err != nil {
+			fmt.Printf("invalid log level: %s\n", options.LogLevel)
+			os.Exit(1)
+		}
+		logrus.SetLevel(level)
 	}
 
 	// Support flag alias: --backfill should cover --backoff --tail.read_from=beginning --tail.stop


### PR DESCRIPTION
## Which problem is this PR solving?
Honeytail logs a summary of every batch of events sent to Honeycomb. These are very repetitive and obscure other information if there was a problem sending events. The summaries are logged at the `INFO` level using logrus.

This PR adds a log level configuration option that allows users to set their desired log level in the logging framework logrus. The usage of info level was verified to not contain critical information if there was a problem, with more important logs using a higher log level (eg `error`).

- Closes #330 

## Short description of the changes
- Add new `log_level` option, defaulting to `info`
- If the new option has a value, attempt to set that log level in logrus

This was tested by setting the `log_level` flag after building the tool locally. As we use flag parsing in main file, it's not easy to write unit tests.