### PR TITLE
Fix honeytail.service file so that honeytail can be enabled in systemd

### DIFF
--- a/honeytail.service
+++ b/honeytail.service
@@ -12,4 +12,4 @@ RestartSec=5
 StartLimitInterval=0
 
 [Install]
-Alias=honeytail honeytail.service
+WantedBy=multi-user.target


### PR DESCRIPTION
## Which problem is this PR solving?

(Started with an issue (https://github.com/honeycombio/honeytail/issues/359) and realized it was more than just on DEB systems, and that the file was right here)

1) There's no need (anymore?) to alias honeytail to honeytail.service

2) as the file it now,It'll let honeytail start, but not be enabled to start at boot time

try to enable honeytail in systemctl

Failed to enable unit: Cannot alias honeytail.service as honeytail.

## Short description of the changes

removing the alias line..

>The unit files have no installation config (WantedBy=, RequiredBy=, UpheldBy=, Also=, or Alias= settings in the [Install] section, and DefaultInstance= for template units). This means they are not meant to be enabled or disabled using systemctl.

adding `WantedBy=multi-user.target`

> Created symlink /etc/systemd/system/multi-user.target.wants/honeytail.service → /usr/lib/systemd/system/honeytail.service.

Lovely, and a reboot confirms that it starts as expected.


