### PR TITLE
rel: prep v1.11.0 release

### DIFF
--- a/.arcconfig
+++ b/.arcconfig
@@ -1,3 +1,0 @@
-{
-  "phabricator.uri" : "https://honeycomb.phacility.com/"
-}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @honeycombio/pipeline-team
+* @honeycombio/oss-maintainers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Honeytail Changelog
 
+## 1.11.0
+
+### ⚠️ Breaking Changes ⚠️
+
+Minimum Go version required is 1.24
+
+### Fixes
+
+- Fix honeytail.service file so that honeytail can be enabled in systemd (#360) | @jerm
+
+### Maintenance
+
+- chore: update to go 1.24, followup tidiness (#361) | @robbkidd
+- maint(deps): bump the minor-patch group across 1 directory with 4 updates (#353) | @(49699333+dependabot[bot]@users.noreply.github.com)
+
 ## 1.10.0
 
 ### ⚠️ Breaking Changes ⚠️

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,8 @@
 # Releasing Process
 
-1. Add release entry to [changelog](./CHANGELOG.md)
-3. Open a PR with the above, and merge that into main
-4. Create new tag on merged commit with the new version (e.g. `v0.2.1`)
-5. Push the tag upstream (this will kick off the release pipeline in CI)
-6. Copy change log entry for newest version into draft GitHub release created as part of CI publish steps
-7. Update [public docs](https://github.com/honeycombio/docs/blob/main/scripts)
+- Add release entry to [changelog](./CHANGELOG.md)
+- Open a PR with the above, and merge that into main
+- Create new tag on merged commit with the new version (e.g. `v0.2.1`)
+- Push the tag upstream (this will kick off the release pipeline in CI)
+- Copy change log entry for newest version into draft GitHub release created as part of CI publish steps
+- Update [public docs](https://github.com/honeycombio/docs/blob/main/scripts)


### PR DESCRIPTION
Preparing v1.11.0 release.

Bonus repo cleanups:
* update CODEOWNERS with latest owning team
* RELEASING step numbers got out of whack, so abandon numbering in favor of bulleted list
* remove config for decommissioned Phabricator service